### PR TITLE
T02. Define the Public API Contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ stream
 ## 🧭 Roadmap
 
 * [x] T01. Establish Solution and Project Skeleton
+* [x] T02. Define the Public API Contracts
 * Structured concurrency support
 * ASP.NET Core integration for reactive endpoints
 * Additional time-based operators

--- a/src/Streamix.Tests/ApiContractTests.cs
+++ b/src/Streamix.Tests/ApiContractTests.cs
@@ -1,0 +1,74 @@
+using NUnit.Framework;
+using Streamix.Abstractions;
+using System.Reflection;
+
+namespace Streamix.Tests;
+
+/// <summary>
+/// This test class ensures that the promised public API surface is available and compiles.
+/// It uses reflection to verify members existence without executing them, as they are currently stubs.
+/// </summary>
+[TestFixture]
+public class ApiContractTests
+{
+    [Test]
+    public void Stream_Contract_Surface_Area_Exists()
+    {
+        var type = typeof(IStream<int>);
+
+        // Factory methods on static facade
+        Assert.That(typeof(Stream).GetMethod("Range"), Is.Not.Null);
+        Assert.That(typeof(Stream).GetMethod("Empty"), Is.Not.Null);
+        Assert.That(typeof(Stream).GetMethod("From"), Is.Not.Null);
+        Assert.That(typeof(Stream).GetMethod("Merge"), Is.Not.Null);
+        Assert.That(typeof(Stream).GetMethods().Any(m => m.Name == "Zip"), Is.True);
+
+        // Instance methods on IStream
+        Assert.That(type.GetMethod("Map"), Is.Not.Null);
+        Assert.That(type.GetMethod("Select"), Is.Not.Null);
+        Assert.That(type.GetMethod("Filter"), Is.Not.Null);
+        Assert.That(type.GetMethod("Where"), Is.Not.Null);
+        Assert.That(type.GetMethods().Any(m => m.Name == "FlatMap"), Is.True);
+        Assert.That(type.GetMethod("FlatMapMany"), Is.Not.Null);
+        Assert.That(type.GetMethod("Take"), Is.Not.Null);
+        Assert.That(type.GetMethod("Skip"), Is.Not.Null);
+        Assert.That(type.GetMethod("Buffer"), Is.Not.Null);
+        Assert.That(type.GetMethod("Window"), Is.Not.Null);
+        Assert.That(type.GetMethod("Throttle"), Is.Not.Null);
+        Assert.That(type.GetMethod("Delay"), Is.Not.Null);
+        Assert.That(type.GetMethod("Retry"), Is.Not.Null);
+        Assert.That(type.GetMethod("Timeout"), Is.Not.Null);
+        Assert.That(type.GetMethod("OnErrorResume"), Is.Not.Null);
+        Assert.That(type.GetMethod("Publish"), Is.Not.Null);
+        Assert.That(type.GetMethod("RunOn"), Is.Not.Null);
+        Assert.That(type.GetMethods().Any(m => m.Name == "ForEachAsync"), Is.True);
+    }
+
+    [Test]
+    public void Single_Contract_Surface_Area_Exists()
+    {
+        var type = typeof(ISingle<int>);
+
+        // Factory methods on static facade
+        Assert.That(typeof(Single).GetMethods().Any(m => m.Name == "From"), Is.True);
+
+        // Instance methods on ISingle
+        Assert.That(type.GetMethod("Map"), Is.Not.Null);
+        Assert.That(type.GetMethod("Select"), Is.Not.Null);
+        Assert.That(type.GetMethod("FlatMap"), Is.Not.Null);
+        Assert.That(type.GetMethod("FlatMapMany"), Is.Not.Null);
+        Assert.That(type.GetMethod("OnErrorResume"), Is.Not.Null);
+        Assert.That(type.GetMethod("RunOn"), Is.Not.Null);
+        Assert.That(type.GetMethods().Any(m => m.Name == "ForEachAsync"), Is.True);
+        Assert.That(type.GetMethod("ToTask"), Is.Not.Null);
+    }
+
+    [Test]
+    public void ConnectableStream_Contract_Surface_Area_Exists()
+    {
+        var type = typeof(IConnectableStream<int>);
+
+        Assert.That(type.GetMethod("Connect"), Is.Not.Null);
+        Assert.That(type.GetMethod("RefCount"), Is.Not.Null);
+    }
+}

--- a/src/Streamix/Abstractions/IConnectableStream.cs
+++ b/src/Streamix/Abstractions/IConnectableStream.cs
@@ -1,0 +1,19 @@
+namespace Streamix.Abstractions;
+
+/// <summary>
+/// Represents a stream that can be connected to a shared source.
+/// </summary>
+/// <typeparam name="T">The type of items in the stream.</typeparam>
+public interface IConnectableStream<T> : IStream<T>
+{
+    /// <summary>
+    /// Connects to the shared source.
+    /// </summary>
+    /// <returns>A disposable to disconnect from the source.</returns>
+    IDisposable Connect();
+
+    /// <summary>
+    /// Returns a stream that stays connected as long as there is at least one subscriber.
+    /// </summary>
+    IStream<T> RefCount();
+}

--- a/src/Streamix/Abstractions/ISingle.cs
+++ b/src/Streamix/Abstractions/ISingle.cs
@@ -1,0 +1,53 @@
+namespace Streamix.Abstractions;
+
+/// <summary>
+/// Represents a stream that can have 0 or 1 item.
+/// </summary>
+/// <typeparam name="T">The type of item in the single-item stream.</typeparam>
+public interface ISingle<T> : IAsyncEnumerable<T>
+{
+    /// <summary>
+    /// Projects the element of a single-item stream into a new form.
+    /// </summary>
+    ISingle<TResult> Map<TResult>(Func<T, TResult> selector);
+
+    /// <summary>
+    /// Projects the element of a single-item stream into a new form. Alias for <see cref="Map{TResult}"/>.
+    /// </summary>
+    ISingle<TResult> Select<TResult>(Func<T, TResult> selector);
+
+    /// <summary>
+    /// Projects the element of a single-item stream to another <see cref="ISingle{TResult}"/> and flattens it.
+    /// </summary>
+    ISingle<TResult> FlatMap<TResult>(Func<T, ISingle<TResult>> selector);
+
+    /// <summary>
+    /// Projects the element of a single-item stream to an <see cref="IStream{TResult}"/> and flattens it.
+    /// </summary>
+    IStream<TResult> FlatMapMany<TResult>(Func<T, IStream<TResult>> selector);
+
+    /// <summary>
+    /// Resumes a single-item stream with another single-item stream if an error occurs.
+    /// </summary>
+    ISingle<T> OnErrorResume(Func<Exception, ISingle<T>> errorHandler);
+
+    /// <summary>
+    /// Executes the single-item stream on the specified scheduler.
+    /// </summary>
+    ISingle<T> RunOn(TaskScheduler scheduler);
+
+    /// <summary>
+    /// Terminal operation that executes an action for the element of the stream.
+    /// </summary>
+    Task ForEachAsync(Action<T> action, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Terminal operation that executes an async action for the element of the stream.
+    /// </summary>
+    Task ForEachAsync(Func<T, Task> action, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Converts the single-item stream to a <see cref="Task{T}"/>.
+    /// </summary>
+    Task<T> ToTask(CancellationToken cancellationToken = default);
+}

--- a/src/Streamix/Abstractions/IStream.cs
+++ b/src/Streamix/Abstractions/IStream.cs
@@ -4,6 +4,111 @@ namespace Streamix.Abstractions;
 /// Represents a stream of 0..N values.
 /// </summary>
 /// <typeparam name="T">The type of items in the stream.</typeparam>
-public interface IStream<out T> : IAsyncEnumerable<T>
+public interface IStream<T> : IAsyncEnumerable<T>
 {
+    /// <summary>
+    /// Projects each element of a stream into a new form.
+    /// </summary>
+    IStream<TResult> Map<TResult>(Func<T, TResult> selector);
+
+    /// <summary>
+    /// Projects each element of a stream into a new form. Alias for <see cref="Map{TResult}"/>.
+    /// </summary>
+    IStream<TResult> Select<TResult>(Func<T, TResult> selector);
+
+    /// <summary>
+    /// Filters a stream of values based on a predicate.
+    /// </summary>
+    IStream<T> Filter(Func<T, bool> predicate);
+
+    /// <summary>
+    /// Filters a stream of values based on a predicate. Alias for <see cref="Filter"/>.
+    /// </summary>
+    IStream<T> Where(Func<T, bool> predicate);
+
+    /// <summary>
+    /// Projects each element of a stream to an <see cref="ISingle{TResult}"/> and flattens the resulting streams into one stream.
+    /// </summary>
+    IStream<TResult> FlatMap<TResult>(Func<T, ISingle<TResult>> selector);
+
+    /// <summary>
+    /// Projects each element of a stream to an <see cref="ISingle{TResult}"/> and flattens the resulting streams into one stream.
+    /// Supports asynchronous projection and concurrency control.
+    /// </summary>
+    IStream<TResult> FlatMap<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency = 1);
+
+    /// <summary>
+    /// Projects each element of a stream to an <see cref="ISingle{TResult}"/> and flattens the resulting streams into one stream. Alias for <see cref="FlatMap{TResult}(Func{T, ISingle{TResult}})"/>.
+    /// </summary>
+    IStream<TResult> SelectMany<TResult>(Func<T, ISingle<TResult>> selector);
+
+    /// <summary>
+    /// Projects each element of a stream to an <see cref="IStream{TResult}"/> and flattens the resulting streams into one stream.
+    /// </summary>
+    IStream<TResult> FlatMapMany<TResult>(Func<T, IStream<TResult>> selector);
+
+    /// <summary>
+    /// Returns a specified number of contiguous elements from the start of a stream.
+    /// </summary>
+    IStream<T> Take(int count);
+
+    /// <summary>
+    /// Bypasses a specified number of elements in a stream and then returns the remaining elements.
+    /// </summary>
+    IStream<T> Skip(int count);
+
+    /// <summary>
+    /// Groups elements of a stream into buffers.
+    /// </summary>
+    IStream<IList<T>> Buffer(int count);
+
+    /// <summary>
+    /// Groups elements of a stream into windows.
+    /// </summary>
+    IStream<IStream<T>> Window(int count);
+
+    /// <summary>
+    /// Throttles a stream by emitting only the first element in each time interval.
+    /// </summary>
+    IStream<T> Throttle(TimeSpan interval);
+
+    /// <summary>
+    /// Delays the emission of each element in a stream by a specified time interval.
+    /// </summary>
+    IStream<T> Delay(TimeSpan interval);
+
+    /// <summary>
+    /// Retries a stream if it fails.
+    /// </summary>
+    IStream<T> Retry(int retryCount = 1);
+
+    /// <summary>
+    /// Terminates a stream with an error if it doesn't emit an element within a specified time interval.
+    /// </summary>
+    IStream<T> Timeout(TimeSpan interval);
+
+    /// <summary>
+    /// Resumes a stream with another stream if an error occurs.
+    /// </summary>
+    IStream<T> OnErrorResume(Func<Exception, IStream<T>> errorHandler);
+
+    /// <summary>
+    /// Shares the source stream.
+    /// </summary>
+    IConnectableStream<T> Publish();
+
+    /// <summary>
+    /// Executes the stream on the specified scheduler.
+    /// </summary>
+    IStream<T> RunOn(TaskScheduler scheduler);
+
+    /// <summary>
+    /// Terminal operation that executes an action for each element of the stream.
+    /// </summary>
+    Task ForEachAsync(Action<T> action, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Terminal operation that executes an async action for each element of the stream.
+    /// </summary>
+    Task ForEachAsync(Func<T, Task> action, CancellationToken cancellationToken = default);
 }

--- a/src/Streamix/Single.cs
+++ b/src/Streamix/Single.cs
@@ -1,0 +1,72 @@
+using Streamix.Abstractions;
+
+namespace Streamix;
+
+/// <summary>
+/// Default implementation of <see cref="ISingle{T}"/>.
+/// This class is sealed to provide a stable API surface and ensure consistent behavior across operator chains.
+/// </summary>
+/// <typeparam name="T">The type of item in the stream.</typeparam>
+public sealed class Single<T> : ISingle<T>
+{
+    private readonly IAsyncEnumerable<T> _source;
+
+    internal Single(IAsyncEnumerable<T> source)
+    {
+        _source = source;
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        return _source.GetAsyncEnumerator(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public ISingle<TResult> Map<TResult>(Func<T, TResult> selector) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public ISingle<TResult> Select<TResult>(Func<T, TResult> selector) => Map(selector);
+
+    /// <inheritdoc />
+    public ISingle<TResult> FlatMap<TResult>(Func<T, ISingle<TResult>> selector) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<TResult> FlatMapMany<TResult>(Func<T, IStream<TResult>> selector) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public ISingle<T> OnErrorResume(Func<Exception, ISingle<T>> errorHandler) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public ISingle<T> RunOn(TaskScheduler scheduler) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public Task ForEachAsync(Action<T> action, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public Task ForEachAsync(Func<T, Task> action, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public Task<T> ToTask(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+}
+
+/// <summary>
+/// Provides static methods for creating single-item streams.
+/// </summary>
+public static class Single
+{
+    /// <summary>
+    /// Creates a <see cref="ISingle{T}"/> from an <see cref="IAsyncEnumerable{T}"/>.
+    /// </summary>
+    public static ISingle<T> From<T>(IAsyncEnumerable<T> source) => new Single<T>(source);
+
+    /// <summary>
+    /// Creates a <see cref="ISingle{T}"/> from a <see cref="Task{T}"/>.
+    /// </summary>
+    public static ISingle<T> From<T>(Task<T> task) => From(ToAsyncEnumerable(task));
+
+    private static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(Task<T> task)
+    {
+        yield return await task;
+    }
+}

--- a/src/Streamix/Stream.cs
+++ b/src/Streamix/Stream.cs
@@ -4,9 +4,10 @@ namespace Streamix;
 
 /// <summary>
 /// Default implementation of <see cref="IStream{T}"/>.
+/// This class is sealed to provide a stable API surface and ensure consistent behavior across operator chains.
 /// </summary>
 /// <typeparam name="T">The type of items in the stream.</typeparam>
-public class Stream<T> : IStream<T>
+public sealed class Stream<T> : IStream<T>
 {
     private readonly IAsyncEnumerable<T> _source;
 
@@ -20,6 +21,79 @@ public class Stream<T> : IStream<T>
     {
         return _source.GetAsyncEnumerator(cancellationToken);
     }
+
+    /// <inheritdoc />
+    public IStream<TResult> Map<TResult>(Func<T, TResult> selector) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<TResult> Select<TResult>(Func<T, TResult> selector) => Map(selector);
+
+    /// <inheritdoc />
+    public IStream<T> Filter(Func<T, bool> predicate) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<T> Where(Func<T, bool> predicate) => Filter(predicate);
+
+    /// <inheritdoc />
+    public IStream<TResult> FlatMap<TResult>(Func<T, ISingle<TResult>> selector) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<TResult> FlatMap<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency = 1) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<TResult> SelectMany<TResult>(Func<T, ISingle<TResult>> selector) => FlatMap(selector);
+
+    /// <inheritdoc />
+    public IStream<TResult> FlatMapMany<TResult>(Func<T, IStream<TResult>> selector) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<T> Take(int count) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<T> Skip(int count) => throw new NotImplementedException();
+
+    /// <summary>
+    /// Merges multiple streams into one by combining their elements.
+    /// </summary>
+    public static IStream<T> Merge(params IStream<T>[] streams) => throw new NotImplementedException();
+
+    /// <summary>
+    /// Combines elements from multiple streams using a specified function.
+    /// </summary>
+    public static IStream<TResult> Zip<T1, T2, TResult>(IStream<T1> first, IStream<T2> second, Func<T1, T2, TResult> resultSelector) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<IList<T>> Buffer(int count) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<IStream<T>> Window(int count) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<T> Throttle(TimeSpan interval) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<T> Delay(TimeSpan interval) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<T> Retry(int retryCount = 1) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<T> Timeout(TimeSpan interval) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<T> OnErrorResume(Func<Exception, IStream<T>> errorHandler) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IConnectableStream<T> Publish() => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IStream<T> RunOn(TaskScheduler scheduler) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public Task ForEachAsync(Action<T> action, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public Task ForEachAsync(Func<T, Task> action, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 }
 
 /// <summary>
@@ -36,6 +110,21 @@ public static class Stream
     /// Creates an empty stream.
     /// </summary>
     public static IStream<T> Empty<T>() => From(AsyncEnumerable.Empty<T>());
+
+    /// <summary>
+    /// Creates a stream that emits a range of sequential integers.
+    /// </summary>
+    public static IStream<int> Range(int start, int count) => From(AsyncEnumerable.Range(start, count));
+
+    /// <summary>
+    /// Merges multiple streams into one by combining their elements.
+    /// </summary>
+    public static IStream<T> Merge<T>(params IStream<T>[] streams) => Stream<T>.Merge(streams);
+
+    /// <summary>
+    /// Combines elements from multiple streams using a specified function.
+    /// </summary>
+    public static IStream<TResult> Zip<T1, T2, TResult>(IStream<T1> first, IStream<T2> second, Func<T1, T2, TResult> resultSelector) => Stream<TResult>.Zip(first, second, resultSelector);
 }
 
 internal static class AsyncEnumerable
@@ -43,5 +132,13 @@ internal static class AsyncEnumerable
     public static async IAsyncEnumerable<T> Empty<T>()
     {
         yield break;
+    }
+
+    public static async IAsyncEnumerable<int> Range(int start, int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            yield return start + i;
+        }
     }
 }


### PR DESCRIPTION
This change locks down the first version of the public API for Streamix. It introduces the core abstractions for 0..N (`Stream<T>`) and 0..1 (`Single<T>`) streams, along with a comprehensive set of operator signatures and factory methods. The implementation uses sealed classes for core types to ensure a stable and consistent API surface, and interfaces are designed to handle both input and output positions of the type parameter. A new test suite verifies that the promised API surface area is correctly defined and accessible.

---
*PR created automatically by Jules for task [13927910146759529942](https://jules.google.com/task/13927910146759529942) started by @khurram-uworx*