### PR TITLE
Implement Core Single Execution Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ stream
 * [x] T01. Establish Solution and Project Skeleton
 * [x] T02. Define the Public API Contracts
 * [x] T03. Implement Core Stream Execution Model
+* [x] T04. Implement Core Single Execution Model
 * Structured concurrency support
 * ASP.NET Core integration for reactive endpoints
 * Additional time-based operators

--- a/src/Streamix.Tests/SingleTests.cs
+++ b/src/Streamix.Tests/SingleTests.cs
@@ -1,0 +1,140 @@
+using NUnit.Framework;
+using Streamix.Abstractions;
+
+namespace Streamix.Tests;
+
+[TestFixture]
+public class SingleTests
+{
+    [Test]
+    public async Task From_Value_Emits_Correct_Value()
+    {
+        ISingle<int> single = Single.From(10);
+        int result = 0;
+        await foreach (var item in single)
+        {
+            result = item;
+        }
+        Assert.That(result, Is.EqualTo(10));
+    }
+
+    [Test]
+    public async Task Empty_Single_Is_Empty()
+    {
+        ISingle<int> single = Single.Empty<int>();
+        int count = 0;
+        await foreach (var _ in single)
+        {
+            count++;
+        }
+        Assert.That(count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Error_Single_Propagates_Exception()
+    {
+        var exception = new InvalidOperationException("Test error");
+        ISingle<int> single = Single.Error<int>(exception);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in single) { }
+        });
+    }
+
+    [Test]
+    public async Task From_Task_Emits_Correct_Value()
+    {
+        ISingle<int> single = Single.From(Task.FromResult(20));
+        int result = 0;
+        await foreach (var item in single)
+        {
+            result = item;
+        }
+        Assert.That(result, Is.EqualTo(20));
+    }
+
+    [Test]
+    public async Task ToTask_Returns_Value()
+    {
+        ISingle<int> single = Single.From(30);
+        int result = await single.ToTask();
+        Assert.That(result, Is.EqualTo(30));
+    }
+
+    [Test]
+    public async Task ToTask_Returns_Default_For_Empty()
+    {
+        ISingle<int> single = Single.Empty<int>();
+        int result = await single.ToTask();
+        Assert.That(result, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task Map_Transforms_Value()
+    {
+        ISingle<int> single = Single.From(5).Map(x => x * 2);
+        int result = await single.ToTask();
+        Assert.That(result, Is.EqualTo(10));
+    }
+
+    [Test]
+    public async Task FlatMap_Transforms_Value()
+    {
+        ISingle<int> single = Single.From(5).FlatMap(x => Single.From(x + 3));
+        int result = await single.ToTask();
+        Assert.That(result, Is.EqualTo(8));
+    }
+
+    [Test]
+    public async Task FlatMapMany_Flattens_To_Stream()
+    {
+        ISingle<int> single = Single.From(3);
+        IStream<int> stream = single.FlatMapMany(x => Stream.Range(1, x));
+        var result = new List<int>();
+        await foreach (var item in stream)
+        {
+            result.Add(item);
+        }
+        Assert.That(result, Is.EqualTo(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public async Task OnErrorResume_Handles_Error()
+    {
+        ISingle<int> single = Single.Error<int>(new Exception("Fail")).OnErrorResume(ex => Single.From(100));
+        int result = await single.ToTask();
+        Assert.That(result, Is.EqualTo(100));
+    }
+
+    [Test]
+    public void Respects_Cancellation()
+    {
+        var cts = new CancellationTokenSource();
+        async IAsyncEnumerable<int> DelayedSource()
+        {
+            await Task.Delay(1000, cts.Token);
+            yield return 1;
+        }
+
+        ISingle<int> single = Single.From(DelayedSource());
+        cts.Cancel();
+
+        Assert.ThrowsAsync<TaskCanceledException>(async () =>
+        {
+            await foreach (var item in single.WithCancellation(cts.Token))
+            {
+            }
+        });
+    }
+
+    [Test]
+    public async Task Single_To_Stream_Interoperability()
+    {
+        ISingle<int> single = Single.From(42);
+        IStream<int> stream = Stream.From(single);
+        var result = new List<int>();
+        await foreach (var item in stream) result.Add(item);
+        Assert.That(result, Is.EqualTo(new[] { 42 }));
+    }
+}

--- a/src/Streamix/Single.cs
+++ b/src/Streamix/Single.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Streamix.Abstractions;
 
 namespace Streamix;
@@ -23,31 +24,177 @@ public sealed class Single<T> : ISingle<T>
     }
 
     /// <inheritdoc />
-    public ISingle<TResult> Map<TResult>(Func<T, TResult> selector) => throw new NotImplementedException();
+    public ISingle<TResult> Map<TResult>(Func<T, TResult> selector)
+    {
+        return new Single<TResult>(MapInternal(selector));
+    }
+
+    private async IAsyncEnumerable<TResult> MapInternal<TResult>(Func<T, TResult> selector, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var item in _source.WithCancellation(ct))
+        {
+            yield return selector(item);
+        }
+    }
 
     /// <inheritdoc />
     public ISingle<TResult> Select<TResult>(Func<T, TResult> selector) => Map(selector);
 
     /// <inheritdoc />
-    public ISingle<TResult> FlatMap<TResult>(Func<T, ISingle<TResult>> selector) => throw new NotImplementedException();
+    public ISingle<TResult> FlatMap<TResult>(Func<T, ISingle<TResult>> selector)
+    {
+        return new Single<TResult>(FlatMapInternal(selector));
+    }
+
+    private async IAsyncEnumerable<TResult> FlatMapInternal<TResult>(Func<T, ISingle<TResult>> selector, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var item in _source.WithCancellation(ct))
+        {
+            await foreach (var innerItem in selector(item).WithCancellation(ct))
+            {
+                yield return innerItem;
+            }
+        }
+    }
 
     /// <inheritdoc />
-    public IStream<TResult> FlatMapMany<TResult>(Func<T, IStream<TResult>> selector) => throw new NotImplementedException();
+    public IStream<TResult> FlatMapMany<TResult>(Func<T, IStream<TResult>> selector)
+    {
+        return new Stream<TResult>(FlatMapManyInternal(selector));
+    }
+
+    private async IAsyncEnumerable<TResult> FlatMapManyInternal<TResult>(Func<T, IStream<TResult>> selector, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var item in _source.WithCancellation(ct))
+        {
+            await foreach (var innerItem in selector(item).WithCancellation(ct))
+            {
+                yield return innerItem;
+            }
+        }
+    }
 
     /// <inheritdoc />
-    public ISingle<T> OnErrorResume(Func<Exception, ISingle<T>> errorHandler) => throw new NotImplementedException();
+    public ISingle<T> OnErrorResume(Func<Exception, ISingle<T>> errorHandler)
+    {
+        return new Single<T>(OnErrorResumeInternal(errorHandler));
+    }
+
+    private async IAsyncEnumerable<T> OnErrorResumeInternal(Func<Exception, ISingle<T>> errorHandler, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        IAsyncEnumerator<T>? enumerator = null;
+        ISingle<T>? resumeSource = null;
+        try
+        {
+            try
+            {
+                enumerator = _source.GetAsyncEnumerator(ct);
+            }
+            catch (Exception ex)
+            {
+                resumeSource = errorHandler(ex);
+            }
+
+            if (enumerator != null)
+            {
+                while (true)
+                {
+                    bool hasNext;
+                    try
+                    {
+                        hasNext = await enumerator.MoveNextAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        resumeSource = errorHandler(ex);
+                        break;
+                    }
+
+                    if (hasNext)
+                    {
+                        yield return enumerator.Current;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            if (enumerator != null)
+            {
+                await enumerator.DisposeAsync();
+            }
+        }
+
+        if (resumeSource != null)
+        {
+            await foreach (var item in resumeSource.WithCancellation(ct))
+            {
+                yield return item;
+            }
+        }
+    }
 
     /// <inheritdoc />
-    public ISingle<T> RunOn(TaskScheduler scheduler) => throw new NotImplementedException();
+    public ISingle<T> RunOn(TaskScheduler scheduler)
+    {
+        return new Single<T>(RunOnInternal(scheduler, ct => _source.GetAsyncEnumerator(ct)));
+    }
+
+    private async IAsyncEnumerable<T> RunOnInternal(TaskScheduler scheduler, Func<CancellationToken, IAsyncEnumerator<T>> enumeratorFactory, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var enumerator = await Task.Factory.StartNew(() => enumeratorFactory(ct), ct, TaskCreationOptions.None, scheduler);
+        try
+        {
+            while (true)
+            {
+                var hasNext = await Task.Factory.StartNew(() => enumerator.MoveNextAsync().AsTask(), ct, TaskCreationOptions.None, scheduler).Unwrap();
+                if (hasNext)
+                {
+                    yield return enumerator.Current;
+                }
+                else
+                {
+                    yield break;
+                }
+            }
+        }
+        finally
+        {
+            await Task.Factory.StartNew(() => enumerator.DisposeAsync().AsTask(), ct, TaskCreationOptions.None, scheduler).Unwrap();
+        }
+    }
 
     /// <inheritdoc />
-    public Task ForEachAsync(Action<T> action, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public async Task ForEachAsync(Action<T> action, CancellationToken cancellationToken = default)
+    {
+        await foreach (var item in this.WithCancellation(cancellationToken))
+        {
+            action(item);
+        }
+    }
 
     /// <inheritdoc />
-    public Task ForEachAsync(Func<T, Task> action, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public async Task ForEachAsync(Func<T, Task> action, CancellationToken cancellationToken = default)
+    {
+        await foreach (var item in this.WithCancellation(cancellationToken))
+        {
+            await action(item);
+        }
+    }
 
     /// <inheritdoc />
-    public Task<T> ToTask(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public async Task<T> ToTask(CancellationToken cancellationToken = default)
+    {
+        await foreach (var item in this.WithCancellation(cancellationToken))
+        {
+            return item;
+        }
+        return default!;
+    }
 }
 
 /// <summary>
@@ -61,12 +208,46 @@ public static class Single
     public static ISingle<T> From<T>(IAsyncEnumerable<T> source) => new Single<T>(source);
 
     /// <summary>
+    /// Creates a <see cref="ISingle{T}"/> from a single value.
+    /// </summary>
+    public static ISingle<T> From<T>(T value) => From(ToAsyncEnumerable(value));
+
+    /// <summary>
     /// Creates a <see cref="ISingle{T}"/> from a <see cref="Task{T}"/>.
     /// </summary>
     public static ISingle<T> From<T>(Task<T> task) => From(ToAsyncEnumerable(task));
 
+    /// <summary>
+    /// Creates an empty <see cref="ISingle{T}"/>.
+    /// </summary>
+    public static ISingle<T> Empty<T>() => From(AsyncEnumerableInternal.Empty<T>());
+
+    /// <summary>
+    /// Creates a <see cref="ISingle{T}"/> that fails with the specified exception.
+    /// </summary>
+    public static ISingle<T> Error<T>(Exception exception) => From(AsyncEnumerableInternal.Error<T>(exception));
+
+    private static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(T value)
+    {
+        yield return value;
+    }
+
     private static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(Task<T> task)
     {
         yield return await task;
+    }
+}
+
+internal static class AsyncEnumerableInternal
+{
+    public static async IAsyncEnumerable<T> Empty<T>([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        yield break;
+    }
+
+    public static async IAsyncEnumerable<T> Error<T>(Exception exception, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        throw exception;
+        yield break;
     }
 }


### PR DESCRIPTION
This PR implements the `Single<T>` abstraction for Streamix, representing a stream of 0 or 1 items.

Key features:
- `Single<T>` implements `ISingle<T>` and `IAsyncEnumerable<T>`.
- Support for creating `Single` from values, `Task<T>`, empty results, and exceptions.
- Core operators like `Map`, `FlatMap`, and `FlatMapMany` (for conversion to `Stream<T>`).
- Error handling with `OnErrorResume`.
- Terminal access via `ToTask()` and `ForEachAsync()`.
- Verified interoperability with `Stream<T>`.
- Full test coverage for success, empty, failure, and cancellation semantics.

---
*PR created automatically by Jules for task [14691296704229579095](https://jules.google.com/task/14691296704229579095) started by @khurram-uworx*