### PR TITLE
Implement Concurrency and Backpressure for FlatMap Operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ await stream
 ```
 
 * `maxConcurrency` controls simultaneous processing
-* Backpressure is automatic via bounded Channels
+* Backpressure is automatic via bounded Channels. When the consumer is slow, the producer is paused once the `maxConcurrency` buffer is full.
 
 ---
 
@@ -190,6 +190,7 @@ stream
 * [x] T05. Implement Fundamental Transformation Operators
 * [x] T06. Implement Flattening Semantics
 * [x] T07. Implement Aggregation and Combination Operators
+* [x] T08. Implement Concurrency and Backpressure
 * Structured concurrency support
 * ASP.NET Core integration for reactive endpoints
 * Additional time-based operators

--- a/src/Streamix.Tests/ConcurrencyTests.cs
+++ b/src/Streamix.Tests/ConcurrencyTests.cs
@@ -1,0 +1,168 @@
+using NUnit.Framework;
+using Streamix.Abstractions;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+
+namespace Streamix.Tests;
+
+[TestFixture]
+public class ConcurrencyTests
+{
+    [Test]
+    public async Task FlatMap_RespectsMaxConcurrency()
+    {
+        const int maxConcurrency = 3;
+        int activeTasks = 0;
+        int maxObservedConcurrency = 0;
+        var lockObj = new object();
+
+        var result = await Stream.Range(1, 10)
+            .FlatMap(async x =>
+            {
+                int currentActive = Interlocked.Increment(ref activeTasks);
+                lock (lockObj)
+                {
+                    maxObservedConcurrency = Math.Max(maxObservedConcurrency, currentActive);
+                }
+
+                await Task.Delay(50);
+
+                Interlocked.Decrement(ref activeTasks);
+                return x;
+            }, maxConcurrency: maxConcurrency)
+            .ToListAsync();
+
+        Assert.That(maxObservedConcurrency, Is.LessThanOrEqualTo(maxConcurrency));
+        Assert.That(result, Is.EquivalentTo(Enumerable.Range(1, 10)));
+    }
+
+    [Test]
+    public async Task FlatMapMany_RespectsMaxConcurrency()
+    {
+        const int maxConcurrency = 2;
+        int activeStreams = 0;
+        int maxObservedStreams = 0;
+        var lockObj = new object();
+
+        var result = await Stream.Range(1, 4)
+            .FlatMapMany(x => Stream.From(GenerateWithTracking(x)), maxConcurrency: maxConcurrency)
+            .ToListAsync();
+
+        async IAsyncEnumerable<int> GenerateWithTracking(int x)
+        {
+            int currentActive = Interlocked.Increment(ref activeStreams);
+            lock (lockObj)
+            {
+                maxObservedStreams = Math.Max(maxObservedStreams, currentActive);
+            }
+
+            yield return x * 10;
+            await Task.Delay(50);
+            yield return x * 10 + 1;
+
+            Interlocked.Decrement(ref activeStreams);
+        }
+
+        Assert.That(maxObservedStreams, Is.LessThanOrEqualTo(maxConcurrency));
+        Assert.That(result, Is.EquivalentTo(new[] { 10, 11, 20, 21, 30, 31, 40, 41 }));
+    }
+
+    [Test]
+    public async Task FlatMap_BackpressureBlocksProducer()
+    {
+        const int maxConcurrency = 2;
+        var pulledItems = new List<int>();
+        var source = Stream.From(GenerateWithLogging(pulledItems));
+
+        var enumerator = source
+            .FlatMap(async x =>
+            {
+                await Task.Delay(10);
+                return x;
+            }, maxConcurrency: maxConcurrency)
+            .GetAsyncEnumerator();
+
+        // Initially nothing pulled
+        Assert.That(pulledItems, Is.Empty);
+
+        // Pull first item
+        Assert.That(await enumerator.MoveNextAsync(), Is.True);
+
+        // Due to maxConcurrency=2 and BoundedChannel(2), the producer can pull:
+        // 1. One item being processed (semaphore wait)
+        // 2. Another item being processed (semaphore wait)
+        // 3. One item waiting to be written to bounded channel (WriteAsync blocks)
+        // Actually, the loop is:
+        // await semaphore.WaitAsync()
+        // Task.Run(...)
+        //   await channel.Writer.WriteAsync(...)
+        //   semaphore.Release()
+
+        // If maxConcurrency is 2:
+        // Iteration 1: semaphore.Wait (success), Task 1 starts.
+        // Iteration 2: semaphore.Wait (success), Task 2 starts.
+        // Iteration 3: semaphore.Wait (blocks)
+
+        // So at most 2 items are pulled from source before semaphore blocks.
+        // If we use Channel.CreateBounded(maxConcurrency), it's another buffer.
+
+        // Let's check how many were pulled. It should be small and bounded.
+        // maxConcurrency (2) are being processed, and 1 might be waiting at semaphore.WaitAsync.
+        // Another one might be pulled by the foreach before it hits the semaphore wait.
+        Assert.That(pulledItems.Count, Is.LessThanOrEqualTo(maxConcurrency + 2));
+
+        int count = 1;
+        while (await enumerator.MoveNextAsync())
+        {
+            count++;
+            // At any point, the number of items pulled from source should not be
+            // significantly larger than what we've consumed + buffer
+            Assert.That(pulledItems.Count, Is.LessThanOrEqualTo(count + maxConcurrency + 1));
+        }
+
+        Assert.That(count, Is.EqualTo(10));
+    }
+
+    private async IAsyncEnumerable<int> GenerateWithLogging(List<int> log, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        for (int i = 1; i <= 10; i++)
+        {
+            log.Add(i);
+            yield return i;
+            await Task.Yield();
+        }
+    }
+
+    [Test]
+    public void FlatMap_PropagatesErrorsCorrectly()
+    {
+        var stream = Stream.Range(1, 10)
+            .FlatMap(async x =>
+            {
+                if (x == 5) throw new InvalidOperationException("Boom");
+                await Task.Yield();
+                return x;
+            }, maxConcurrency: 2);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await stream.ToListAsync());
+    }
+
+    [Test]
+    public async Task FlatMap_OrderingIsNonDeterministic()
+    {
+        // We want to prove that with concurrency, results can arrive out of order
+        // if they take different amounts of time.
+        var result = await Stream.Range(1, 5)
+            .FlatMap(async x =>
+            {
+                // Task for 1 takes 100ms, others take 1ms
+                await Task.Delay(x == 1 ? 100 : 1);
+                return x;
+            }, maxConcurrency: 5)
+            .ToListAsync();
+
+        // 1 should NOT be first because it was delayed
+        Assert.That(result[0], Is.Not.EqualTo(1));
+        Assert.That(result, Is.EquivalentTo(new[] { 1, 2, 3, 4, 5 }));
+    }
+}

--- a/src/Streamix/Abstractions/IStream.cs
+++ b/src/Streamix/Abstractions/IStream.cs
@@ -28,8 +28,9 @@ public interface IStream<T> : IAsyncEnumerable<T>
 
     /// <summary>
     /// Projects each element of a stream to an <see cref="ISingle{TResult}"/> and flattens the resulting streams into one stream.
+    /// Supports concurrency control.
     /// </summary>
-    IStream<TResult> FlatMap<TResult>(Func<T, ISingle<TResult>> selector);
+    IStream<TResult> FlatMap<TResult>(Func<T, ISingle<TResult>> selector, int maxConcurrency = 1);
 
     /// <summary>
     /// Projects each element of a stream to an <see cref="ISingle{TResult}"/> and flattens the resulting streams into one stream.
@@ -38,14 +39,15 @@ public interface IStream<T> : IAsyncEnumerable<T>
     IStream<TResult> FlatMap<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency = 1);
 
     /// <summary>
-    /// Projects each element of a stream to an <see cref="ISingle{TResult}"/> and flattens the resulting streams into one stream. Alias for <see cref="FlatMap{TResult}(Func{T, ISingle{TResult}})"/>.
+    /// Projects each element of a stream to an <see cref="ISingle{TResult}"/> and flattens the resulting streams into one stream. Alias for <see cref="FlatMap{TResult}(Func{T, ISingle{TResult}}, int)"/>.
     /// </summary>
-    IStream<TResult> SelectMany<TResult>(Func<T, ISingle<TResult>> selector);
+    IStream<TResult> SelectMany<TResult>(Func<T, ISingle<TResult>> selector, int maxConcurrency = 1);
 
     /// <summary>
     /// Projects each element of a stream to an <see cref="IStream{TResult}"/> and flattens the resulting streams into one stream.
+    /// Supports concurrency control.
     /// </summary>
-    IStream<TResult> FlatMapMany<TResult>(Func<T, IStream<TResult>> selector);
+    IStream<TResult> FlatMapMany<TResult>(Func<T, IStream<TResult>> selector, int maxConcurrency = 1);
 
     /// <summary>
     /// Returns a specified number of contiguous elements from the start of a stream.

--- a/src/Streamix/Stream.cs
+++ b/src/Streamix/Stream.cs
@@ -62,9 +62,12 @@ public sealed class Stream<T> : IStream<T>
     public IStream<T> Where(Func<T, bool> predicate) => Filter(predicate);
 
     /// <inheritdoc />
-    public IStream<TResult> FlatMap<TResult>(Func<T, ISingle<TResult>> selector)
+    public IStream<TResult> FlatMap<TResult>(Func<T, ISingle<TResult>> selector, int maxConcurrency = 1)
     {
-        return Stream.From(FlatMapInternal(selector));
+        if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
+        return maxConcurrency == 1
+            ? Stream.From(FlatMapInternal(selector))
+            : Stream.From(FlatMapManyConcurrentInternal(selector, maxConcurrency));
     }
 
     private async IAsyncEnumerable<TResult> FlatMapInternal<TResult>(Func<T, ISingle<TResult>> selector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -96,7 +99,7 @@ public sealed class Stream<T> : IStream<T>
             yield break;
         }
 
-        var channel = Channel.CreateUnbounded<TResult>();
+        var channel = Channel.CreateBounded<TResult>(maxConcurrency);
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
@@ -116,6 +119,11 @@ public sealed class Stream<T> : IStream<T>
                         {
                             var result = await selector(item);
                             await channel.Writer.WriteAsync(result, cts.Token);
+                        }
+                        catch (Exception ex)
+                        {
+                            channel.Writer.TryComplete(ex);
+                            throw;
                         }
                         finally
                         {
@@ -146,36 +154,47 @@ public sealed class Stream<T> : IStream<T>
 
         try
         {
-            while (await channel.Reader.WaitToReadAsync(cancellationToken))
+            while (true)
             {
+                bool hasMore;
+                try
+                {
+                    hasMore = await channel.Reader.WaitToReadAsync(cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                if (!hasMore) break;
+
                 while (channel.Reader.TryRead(out var result))
                 {
                     yield return result;
                 }
             }
+
+            // Wait for producer to complete and check for exceptions
+            await producerTask;
+            await channel.Reader.Completion;
         }
         finally
         {
             await cts.CancelAsync();
-        }
-
-        try
-        {
-            await producerTask;
-        }
-        catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
-        {
-            // Expected when we cancel the producer task
+            try { await producerTask; } catch { }
         }
     }
 
     /// <inheritdoc />
-    public IStream<TResult> SelectMany<TResult>(Func<T, ISingle<TResult>> selector) => FlatMap(selector);
+    public IStream<TResult> SelectMany<TResult>(Func<T, ISingle<TResult>> selector, int maxConcurrency = 1) => FlatMap(selector, maxConcurrency);
 
     /// <inheritdoc />
-    public IStream<TResult> FlatMapMany<TResult>(Func<T, IStream<TResult>> selector)
+    public IStream<TResult> FlatMapMany<TResult>(Func<T, IStream<TResult>> selector, int maxConcurrency = 1)
     {
-        return Stream.From(FlatMapManyInternal(selector));
+        if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
+        return maxConcurrency == 1
+            ? Stream.From(FlatMapManyInternal(selector))
+            : Stream.From(FlatMapManyConcurrentInternal(selector, maxConcurrency));
     }
 
     private async IAsyncEnumerable<TResult> FlatMapManyInternal<TResult>(Func<T, IStream<TResult>> selector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -186,6 +205,96 @@ public sealed class Stream<T> : IStream<T>
             {
                 yield return innerItem;
             }
+        }
+    }
+
+    private async IAsyncEnumerable<TResult> FlatMapManyConcurrentInternal<TResult>(Func<T, IAsyncEnumerable<TResult>> selector, int maxConcurrency, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var channel = Channel.CreateBounded<TResult>(maxConcurrency);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        var producerTask = Task.Run(async () =>
+        {
+            var semaphore = new SemaphoreSlim(maxConcurrency);
+            var tasks = new List<Task>();
+            try
+            {
+                await foreach (var item in this.WithCancellation(cts.Token))
+                {
+                    await semaphore.WaitAsync(cts.Token);
+
+                    var task = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await foreach (var result in selector(item).WithCancellation(cts.Token))
+                            {
+                                await channel.Writer.WriteAsync(result, cts.Token);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            channel.Writer.TryComplete(ex);
+                            throw;
+                        }
+                        finally
+                        {
+                            semaphore.Release();
+                        }
+                    }, cts.Token);
+
+                    tasks.Add(task);
+                    tasks.RemoveAll(t => t.IsCompleted);
+                }
+
+                await Task.WhenAll(tasks);
+                channel.Writer.Complete();
+            }
+            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
+            {
+                channel.Writer.TryComplete();
+            }
+            catch (Exception ex)
+            {
+                channel.Writer.TryComplete(ex);
+            }
+            finally
+            {
+                semaphore.Dispose();
+            }
+        }, cts.Token);
+
+        try
+        {
+            while (true)
+            {
+                bool hasMore;
+                try
+                {
+                    hasMore = await channel.Reader.WaitToReadAsync(cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                if (!hasMore) break;
+
+                while (channel.Reader.TryRead(out var result))
+                {
+                    yield return result;
+                }
+            }
+
+            // Wait for producer to complete and check for exceptions
+            await producerTask;
+            await channel.Reader.Completion;
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await producerTask; } catch { }
         }
     }
 


### PR DESCRIPTION
This change implements bounded concurrency and backpressure-safe execution for the `FlatMap` and `FlatMapMany` operators in `Streamix`. It introduces the use of `SemaphoreSlim` and `Channel.CreateBounded<TResult>(maxConcurrency)` to ensure that no more than `maxConcurrency` items are being processed or buffered simultaneously. When the downstream consumer is slow, the producer is automatically paused once the channel capacity is reached.

Key changes:
- Added `int maxConcurrency = 1` to `FlatMap` and `FlatMapMany` overloads in `IStream.cs`.
- Modified `Stream.cs` to use `Channel.CreateBounded(maxConcurrency)` for concurrent operations.
- Implemented `FlatMapManyConcurrentInternal` to handle multi-item inner streams with concurrency.
- Fixed error propagation bug in concurrent tasks where exceptions were not being correctly signaled to the consumer.
- Added `ConcurrencyTests.cs` to verify these behaviors.
- Updated `README.md` to document backpressure and mark task T08 as complete.

---
*PR created automatically by Jules for task [15902865117015047869](https://jules.google.com/task/15902865117015047869) started by @khurram-uworx*