### PR TITLE
Implement Error Recovery APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ stream
 * [x] T07. Implement Aggregation and Combination Operators
 * [x] T08. Implement Concurrency and Backpressure
 * [x] T09. Implement Buffer and Window Operators
+* [x] T11. Implement Error Recovery APIs
 * Structured concurrency support
 * ASP.NET Core integration for reactive endpoints
 * Additional time-based operators

--- a/src/Streamix.Tests/ApiContractTests.cs
+++ b/src/Streamix.Tests/ApiContractTests.cs
@@ -19,7 +19,7 @@ public class ApiContractTests
         // Factory methods on static facade
         Assert.That(typeof(Stream).GetMethod("Range"), Is.Not.Null);
         Assert.That(typeof(Stream).GetMethod("Empty"), Is.Not.Null);
-        Assert.That(typeof(Stream).GetMethod("From"), Is.Not.Null);
+        Assert.That(typeof(Stream).GetMethods().Any(m => m.Name == "From"), Is.True);
         Assert.That(typeof(Stream).GetMethod("Merge"), Is.Not.Null);
         Assert.That(typeof(Stream).GetMethods().Any(m => m.Name == "Zip"), Is.True);
 
@@ -39,6 +39,8 @@ public class ApiContractTests
         Assert.That(type.GetMethod("Retry"), Is.Not.Null);
         Assert.That(type.GetMethod("Timeout"), Is.Not.Null);
         Assert.That(type.GetMethod("OnErrorResume"), Is.Not.Null);
+        Assert.That(type.GetMethod("OnErrorReturn"), Is.Not.Null);
+        Assert.That(type.GetMethod("OnErrorMap"), Is.Not.Null);
         Assert.That(type.GetMethod("Publish"), Is.Not.Null);
         Assert.That(type.GetMethod("RunOn"), Is.Not.Null);
         Assert.That(type.GetMethods().Any(m => m.Name == "ForEachAsync"), Is.True);
@@ -58,6 +60,8 @@ public class ApiContractTests
         Assert.That(type.GetMethod("FlatMap"), Is.Not.Null);
         Assert.That(type.GetMethod("FlatMapMany"), Is.Not.Null);
         Assert.That(type.GetMethod("OnErrorResume"), Is.Not.Null);
+        Assert.That(type.GetMethod("OnErrorReturn"), Is.Not.Null);
+        Assert.That(type.GetMethod("OnErrorMap"), Is.Not.Null);
         Assert.That(type.GetMethod("RunOn"), Is.Not.Null);
         Assert.That(type.GetMethods().Any(m => m.Name == "ForEachAsync"), Is.True);
         Assert.That(type.GetMethod("ToTask"), Is.Not.Null);

--- a/src/Streamix.Tests/ErrorHandlingTests.cs
+++ b/src/Streamix.Tests/ErrorHandlingTests.cs
@@ -1,0 +1,173 @@
+using NUnit.Framework;
+using Streamix.Abstractions;
+
+namespace Streamix.Tests;
+
+[TestFixture]
+public class ErrorHandlingTests
+{
+    #region Stream Tests
+
+    [Test]
+    public async Task Stream_OnErrorResume_Recovers_From_Error()
+    {
+        var exception = new InvalidOperationException("Initial failure");
+        IStream<int> stream = Stream.Error<int>(exception)
+            .OnErrorResume(ex =>
+            {
+                Assert.That(ex, Is.SameAs(exception));
+                return Stream.Range(1, 3);
+            });
+
+        var result = new List<int>();
+        await foreach (var item in stream)
+        {
+            result.Add(item);
+        }
+
+        Assert.That(result, Is.EqualTo(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public async Task Stream_OnErrorResume_MidStream_Recovers()
+    {
+        async IAsyncEnumerable<int> FailingSource()
+        {
+            yield return 1;
+            yield return 2;
+            throw new Exception("Boom");
+        }
+
+        IStream<int> stream = Stream.From(FailingSource())
+            .OnErrorResume(ex => Stream.From(100));
+
+        var result = new List<int>();
+        await foreach (var item in stream)
+        {
+            result.Add(item);
+        }
+
+        Assert.That(result, Is.EqualTo(new[] { 1, 2, 100 }));
+    }
+
+    [Test]
+    public void Stream_OnErrorResume_Propagates_Recovery_Failure()
+    {
+        var recoveryException = new Exception("Recovery failed");
+        IStream<int> stream = Stream.Error<int>(new Exception("Initial"))
+            .OnErrorResume(ex => throw recoveryException);
+
+        Assert.ThrowsAsync<Exception>(async () =>
+        {
+            await foreach (var _ in stream) { }
+        }, "Recovery failed");
+    }
+
+    [Test]
+    public async Task Stream_OnErrorReturn_Returns_Value()
+    {
+        IStream<int> stream = Stream.Error<int>(new Exception("Fail"))
+            .OnErrorReturn(42);
+
+        var result = new List<int>();
+        await foreach (var item in stream) result.Add(item);
+
+        Assert.That(result, Is.EqualTo(new[] { 42 }));
+    }
+
+    [Test]
+    public void Stream_OnErrorMap_Transforms_Exception()
+    {
+        IStream<int> stream = Stream.Error<int>(new InvalidOperationException("Original"))
+            .OnErrorMap(ex => new ArgumentException("Mapped", ex));
+
+        var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+        {
+            await foreach (var _ in stream) { }
+        });
+        Assert.That(ex.Message, Is.EqualTo("Mapped"));
+        Assert.That(ex.InnerException, Is.InstanceOf<InvalidOperationException>());
+    }
+
+    [Test]
+    public async Task Stream_ErrorOperators_NoOp_When_No_Error()
+    {
+        IStream<int> stream = Stream.Range(1, 3)
+            .OnErrorResume(ex => Stream.From(10))
+            .OnErrorReturn(20)
+            .OnErrorMap(ex => new Exception("Should not happen"));
+
+        var result = new List<int>();
+        await foreach (var item in stream) result.Add(item);
+
+        Assert.That(result, Is.EqualTo(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public void Stream_OnErrorResume_Respects_Cancellation()
+    {
+        var cts = new CancellationTokenSource();
+        IStream<int> stream = Stream.Error<int>(new Exception("Fail"))
+            .OnErrorResume(ex => Stream.Range(1, 100));
+
+        cts.Cancel();
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var item in stream.WithCancellation(cts.Token))
+            {
+            }
+        });
+    }
+
+    #endregion
+
+    #region Single Tests
+
+    [Test]
+    public async Task Single_OnErrorResume_Recovers()
+    {
+        ISingle<int> single = Single.Error<int>(new Exception("Fail"))
+            .OnErrorResume(ex => Single.From(42));
+
+        int result = await single.ToTask();
+        Assert.That(result, Is.EqualTo(42));
+    }
+
+    [Test]
+    public async Task Single_OnErrorReturn_Returns_Value()
+    {
+        ISingle<int> single = Single.Error<int>(new Exception("Fail"))
+            .OnErrorReturn(42);
+
+        int result = await single.ToTask();
+        Assert.That(result, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void Single_OnErrorMap_Transforms_Exception()
+    {
+        ISingle<int> single = Single.Error<int>(new InvalidOperationException("Original"))
+            .OnErrorMap(ex => new ArgumentException("Mapped", ex));
+
+        var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+        {
+            await single.ToTask();
+        });
+        Assert.That(ex.Message, Is.EqualTo("Mapped"));
+    }
+
+    [Test]
+    public async Task Single_ErrorOperators_NoOp_When_No_Error()
+    {
+        ISingle<int> single = Single.From(1)
+            .OnErrorResume(ex => Single.From(10))
+            .OnErrorReturn(20)
+            .OnErrorMap(ex => new Exception("Should not happen"));
+
+        int result = await single.ToTask();
+        Assert.That(result, Is.EqualTo(1));
+    }
+
+    #endregion
+}

--- a/src/Streamix/Abstractions/ISingle.cs
+++ b/src/Streamix/Abstractions/ISingle.cs
@@ -32,6 +32,16 @@ public interface ISingle<T> : IAsyncEnumerable<T>
     ISingle<T> OnErrorResume(Func<Exception, ISingle<T>> errorHandler);
 
     /// <summary>
+    /// Resumes a single-item stream with a single value if an error occurs.
+    /// </summary>
+    ISingle<T> OnErrorReturn(T value);
+
+    /// <summary>
+    /// Maps the error into another exception.
+    /// </summary>
+    ISingle<T> OnErrorMap(Func<Exception, Exception> mapper);
+
+    /// <summary>
     /// Executes the single-item stream on the specified scheduler.
     /// </summary>
     ISingle<T> RunOn(TaskScheduler scheduler);

--- a/src/Streamix/Abstractions/IStream.cs
+++ b/src/Streamix/Abstractions/IStream.cs
@@ -105,6 +105,16 @@ public interface IStream<T> : IAsyncEnumerable<T>
     IStream<T> OnErrorResume(Func<Exception, IStream<T>> errorHandler);
 
     /// <summary>
+    /// Resumes a stream with a single element if an error occurs.
+    /// </summary>
+    IStream<T> OnErrorReturn(T value);
+
+    /// <summary>
+    /// Maps the error into another exception.
+    /// </summary>
+    IStream<T> OnErrorMap(Func<Exception, Exception> mapper);
+
+    /// <summary>
     /// Shares the source stream.
     /// </summary>
     IConnectableStream<T> Publish();

--- a/src/Streamix/Single.cs
+++ b/src/Streamix/Single.cs
@@ -80,6 +80,18 @@ public sealed class Single<T> : ISingle<T>
         return new Single<T>(OnErrorResumeInternal(errorHandler));
     }
 
+    /// <inheritdoc />
+    public ISingle<T> OnErrorReturn(T value)
+    {
+        return OnErrorResume(_ => Single.From(value));
+    }
+
+    /// <inheritdoc />
+    public ISingle<T> OnErrorMap(Func<Exception, Exception> mapper)
+    {
+        return OnErrorResume(ex => Single.Error<T>(mapper(ex)));
+    }
+
     private async IAsyncEnumerable<T> OnErrorResumeInternal(Func<Exception, ISingle<T>> errorHandler, [EnumeratorCancellation] CancellationToken ct = default)
     {
         IAsyncEnumerator<T>? enumerator = null;

--- a/src/Streamix/Stream.cs
+++ b/src/Streamix/Stream.cs
@@ -512,7 +512,80 @@ public sealed class Stream<T> : IStream<T>
     public IStream<T> Timeout(TimeSpan interval) => throw new NotImplementedException();
 
     /// <inheritdoc />
-    public IStream<T> OnErrorResume(Func<Exception, IStream<T>> errorHandler) => throw new NotImplementedException();
+    public IStream<T> OnErrorResume(Func<Exception, IStream<T>> errorHandler)
+    {
+        return Stream.From(OnErrorResumeInternal(errorHandler));
+    }
+
+    private async IAsyncEnumerable<T> OnErrorResumeInternal(Func<Exception, IStream<T>> errorHandler, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        IAsyncEnumerator<T>? enumerator = null;
+        IStream<T>? resumeSource = null;
+        try
+        {
+            try
+            {
+                enumerator = _source.GetAsyncEnumerator(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                resumeSource = errorHandler(ex);
+            }
+
+            if (enumerator != null)
+            {
+                while (true)
+                {
+                    bool hasNext;
+                    try
+                    {
+                        hasNext = await enumerator.MoveNextAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        resumeSource = errorHandler(ex);
+                        break;
+                    }
+
+                    if (hasNext)
+                    {
+                        yield return enumerator.Current;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            if (enumerator != null)
+            {
+                await enumerator.DisposeAsync();
+            }
+        }
+
+        if (resumeSource != null)
+        {
+            await foreach (var item in resumeSource.WithCancellation(cancellationToken))
+            {
+                yield return item;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public IStream<T> OnErrorReturn(T value)
+    {
+        return OnErrorResume(_ => Stream.From(value));
+    }
+
+    /// <inheritdoc />
+    public IStream<T> OnErrorMap(Func<Exception, Exception> mapper)
+    {
+        return OnErrorResume(ex => Stream.Error<T>(mapper(ex)));
+    }
 
     /// <inheritdoc />
     public IConnectableStream<T> Publish() => throw new NotImplementedException();
@@ -547,12 +620,31 @@ public static class Stream
     /// <summary>
     /// Creates a stream from an <see cref="IAsyncEnumerable{T}"/>.
     /// </summary>
-    public static IStream<T> From<T>(IAsyncEnumerable<T> source) => new Stream<T>(source);
+    public static IStream<T> From<T>(IAsyncEnumerable<T> source)
+    {
+        if (source is IStream<T> stream) return stream;
+        return new Stream<T>(source);
+    }
+
+    /// <summary>
+    /// Creates a stream from a <see cref="ISingle{T}"/>.
+    /// </summary>
+    public static IStream<T> From<T>(ISingle<T> source) => new Stream<T>(source);
+
+    /// <summary>
+    /// Creates a stream from a single value.
+    /// </summary>
+    public static IStream<T> From<T>(T value) => From(AsyncEnumerable.Just(value));
 
     /// <summary>
     /// Creates an empty stream.
     /// </summary>
     public static IStream<T> Empty<T>() => From(AsyncEnumerable.Empty<T>());
+
+    /// <summary>
+    /// Creates a stream that fails with the specified exception.
+    /// </summary>
+    public static IStream<T> Error<T>(Exception exception) => From(AsyncEnumerable.Error<T>(exception));
 
     /// <summary>
     /// Creates a stream that emits a range of sequential integers.
@@ -574,6 +666,17 @@ internal static class AsyncEnumerable
 {
     public static async IAsyncEnumerable<T> Empty<T>([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        yield break;
+    }
+
+    public static async IAsyncEnumerable<T> Just<T>(T value, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        yield return value;
+    }
+
+    public static async IAsyncEnumerable<T> Error<T>(Exception exception, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        throw exception;
         yield break;
     }
 


### PR DESCRIPTION
This PR implements OnErrorResume, OnErrorReturn, and OnErrorMap for both Stream<T> and Single<T> abstractions. It also adds static factory methods for creating failing streams and single-item streams, and provides comprehensive tests for these new operators.

---
*PR created automatically by Jules for task [6623944922845378820](https://jules.google.com/task/6623944922845378820) started by @khurram-uworx*