### PR TITLE
Add missing SingleAsync terminal operators for IStream<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ var hot  = cold.Publish().RefCount(); // shared hot stream
 * `Throttle` / `Delay`
 * `Retry` / `Timeout`
 * `Take` / `Skip`
+* `FirstAsync` / `LastAsync` / `SingleAsync` (and `OrDefault` variants)
+* `AggregateAsync` / `CountAsync` / `AnyAsync` / `AllAsync`
 
 ---
 

--- a/src/Streamix.Tests/AggregationOperatorTests.cs
+++ b/src/Streamix.Tests/AggregationOperatorTests.cs
@@ -236,4 +236,58 @@ public class AggregationOperatorTests
 
         Assert.That(result, Is.EqualTo(new[] { 11, 13 }));
     }
+
+    [Test]
+    public async Task SingleAsync_Returns_Element_When_One_Element_Exists()
+    {
+        var result = await Stream.Range(1, 1).SingleAsync(); // Just 1
+        Assert.That(result, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void SingleAsync_Throws_When_Empty()
+    {
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await Stream.Empty<int>().SingleAsync());
+        Assert.That(ex?.Message, Is.EqualTo("Sequence contains no elements."));
+    }
+
+    [Test]
+    public void SingleAsync_Throws_When_Multiple_Elements()
+    {
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await Stream.Range(1, 2).SingleAsync()); // 1, 2
+        Assert.That(ex?.Message, Is.EqualTo("Sequence contains more than one element."));
+    }
+
+    [Test]
+    public async Task SingleOrDefaultAsync_Returns_Element_When_One_Element_Exists()
+    {
+        var result = await Stream.Range(1, 1).SingleOrDefaultAsync();
+        Assert.That(result, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task SingleOrDefaultAsync_Returns_Default_When_Empty()
+    {
+        var result = await Stream.Empty<int>().SingleOrDefaultAsync();
+        Assert.That(result, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void SingleOrDefaultAsync_Throws_When_Multiple_Elements()
+    {
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await Stream.Range(1, 2).SingleOrDefaultAsync());
+        Assert.That(ex?.Message, Is.EqualTo("Sequence contains more than one element."));
+    }
+
+    [Test]
+    public void SingleAsync_Respects_Cancellation()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await Stream.Range(1, 1).SingleAsync(cts.Token));
+    }
 }

--- a/src/Streamix.Tests/ApiContractTests.cs
+++ b/src/Streamix.Tests/ApiContractTests.cs
@@ -43,6 +43,18 @@ public class ApiContractTests
         Assert.That(type.GetMethod("Publish"), Is.Not.Null);
         Assert.That(type.GetMethod("RunOn"), Is.Not.Null);
         Assert.That(type.GetMethods().Any(m => m.Name == "ForEachAsync"), Is.True);
+
+        // Terminal extensions (LINQ style)
+        var extensionsType = typeof(TerminalExtensions);
+        Assert.That(extensionsType.GetMethods().Any(m => m.Name == "FirstAsync"), Is.True);
+        Assert.That(extensionsType.GetMethods().Any(m => m.Name == "FirstOrDefaultAsync"), Is.True);
+        Assert.That(extensionsType.GetMethods().Any(m => m.Name == "LastAsync"), Is.True);
+        Assert.That(extensionsType.GetMethods().Any(m => m.Name == "LastOrDefaultAsync"), Is.True);
+        Assert.That(extensionsType.GetMethods().Any(m => m.Name == "SingleAsync"), Is.True);
+        Assert.That(extensionsType.GetMethods().Any(m => m.Name == "SingleOrDefaultAsync"), Is.True);
+        Assert.That(extensionsType.GetMethods().Any(m => m.Name == "CountAsync"), Is.True);
+        Assert.That(extensionsType.GetMethods().Any(m => m.Name == "AnyAsync"), Is.True);
+        Assert.That(extensionsType.GetMethods().Any(m => m.Name == "AllAsync"), Is.True);
     }
 
     [Test]

--- a/src/Streamix/Extensions/TerminalExtensions.cs
+++ b/src/Streamix/Extensions/TerminalExtensions.cs
@@ -606,4 +606,57 @@ public static class TerminalExtensions
 
         return sum / count;
     }
+
+    /// <summary>
+    /// Returns the only item from the stream, or throws if the stream does not contain exactly one item.
+    /// </summary>
+    /// <typeparam name="T">The type of items in the stream.</typeparam>
+    /// <param name="stream">The source stream.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that returns the only item from the stream.</returns>
+    /// <exception cref="InvalidOperationException">The stream is empty or contains more than one item.</exception>
+    public static async Task<T> SingleAsync<T>(this IStream<T> stream, CancellationToken cancellationToken = default)
+    {
+        T? first = default;
+        bool hasValue = false;
+
+        await foreach (var item in stream.WithCancellation(cancellationToken))
+        {
+            if (hasValue)
+                throw new InvalidOperationException("Sequence contains more than one element.");
+
+            first = item;
+            hasValue = true;
+        }
+
+        if (!hasValue)
+            throw new InvalidOperationException("Sequence contains no elements.");
+
+        return first!;
+    }
+
+    /// <summary>
+    /// Returns the only item from the stream, or a default value if the stream is empty. Throws if the stream contains more than one item.
+    /// </summary>
+    /// <typeparam name="T">The type of items in the stream.</typeparam>
+    /// <param name="stream">The source stream.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that returns the only item from the stream, or the default value of T if empty.</returns>
+    /// <exception cref="InvalidOperationException">The stream contains more than one item.</exception>
+    public static async Task<T?> SingleOrDefaultAsync<T>(this IStream<T> stream, CancellationToken cancellationToken = default)
+    {
+        T? first = default;
+        bool hasValue = false;
+
+        await foreach (var item in stream.WithCancellation(cancellationToken))
+        {
+            if (hasValue)
+                throw new InvalidOperationException("Sequence contains more than one element.");
+
+            first = item;
+            hasValue = true;
+        }
+
+        return first;
+    }
 }


### PR DESCRIPTION
This change adds the missing `SingleAsync` and `SingleOrDefaultAsync` terminal operators to the `IStream<T>` interface, closing a gap in the API surface. The implementation follows .NET/LINQ semantics, throwing `InvalidOperationException` with standard messages when the sequence doesn't meet the expected criteria (exactly one element for `SingleAsync`, and zero or one for `SingleOrDefaultAsync`). 

In addition to the new operators, this PR:
1. Updates `ApiContractTests` to ensure all terminal operators (including `FirstAsync`, `LastAsync`, `CountAsync`, `AnyAsync`, `AllAsync`) are verified as part of the public API.
2. Adds unit tests covering empty, single-item, and multi-item sequence behaviors for the new operators.
3. Updates `README.md` to document the full suite of terminal operators.
4. Ensures proper cancellation support across the new operators.

---
*PR created automatically by Jules for task [7153250246901274591](https://jules.google.com/task/7153250246901274591) started by @khurram-uworx*