### PR TITLE
Add ParallelMap and ParallelMapOrdered operators

### DIFF
--- a/src/Streamix.Tests/ConcurrencyTests.cs
+++ b/src/Streamix.Tests/ConcurrencyTests.cs
@@ -163,4 +163,105 @@ public class ConcurrencyTests
         Assert.That(result[0], Is.Not.EqualTo(1));
         Assert.That(result, Is.EquivalentTo(new[] { 1, 2, 3, 4, 5 }));
     }
+
+    [Test]
+    public async Task ParallelMap_RespectsMaxConcurrency()
+    {
+        const int maxConcurrency = 3;
+        int activeTasks = 0;
+        int maxObservedConcurrency = 0;
+        var lockObj = new object();
+
+        var result = await Stream.Range(1, 10)
+            .ParallelMap(async x =>
+            {
+                int currentActive = Interlocked.Increment(ref activeTasks);
+                lock (lockObj)
+                {
+                    maxObservedConcurrency = Math.Max(maxObservedConcurrency, currentActive);
+                }
+
+                await Task.Delay(50);
+
+                Interlocked.Decrement(ref activeTasks);
+                return x;
+            }, maxConcurrency: maxConcurrency)
+            .ToListAsync();
+
+        Assert.That(maxObservedConcurrency, Is.LessThanOrEqualTo(maxConcurrency));
+        Assert.That(result, Is.EquivalentTo(Enumerable.Range(1, 10)));
+    }
+
+    [Test]
+    public async Task ParallelMapOrdered_RespectsMaxConcurrency()
+    {
+        const int maxConcurrency = 3;
+        int activeTasks = 0;
+        int maxObservedConcurrency = 0;
+        var lockObj = new object();
+
+        var result = await Stream.Range(1, 10)
+            .ParallelMapOrdered(async x =>
+            {
+                int currentActive = Interlocked.Increment(ref activeTasks);
+                lock (lockObj)
+                {
+                    maxObservedConcurrency = Math.Max(maxObservedConcurrency, currentActive);
+                }
+
+                await Task.Delay(50);
+
+                Interlocked.Decrement(ref activeTasks);
+                return x;
+            }, maxConcurrency: maxConcurrency)
+            .ToListAsync();
+
+        Assert.That(maxObservedConcurrency, Is.LessThanOrEqualTo(maxConcurrency));
+        Assert.That(result, Is.EqualTo(Enumerable.Range(1, 10)));
+    }
+
+    [Test]
+    public async Task ParallelMapOrdered_PreservesOrder()
+    {
+        var result = await Stream.Range(1, 5)
+            .ParallelMapOrdered(async x =>
+            {
+                // Task for 1 takes 100ms, others take 1ms
+                await Task.Delay(x == 1 ? 100 : 1);
+                return x;
+            }, maxConcurrency: 5)
+            .ToListAsync();
+
+        // 1 SHOULD be first because it's ordered
+        Assert.That(result[0], Is.EqualTo(1));
+        Assert.That(result, Is.EqualTo(new[] { 1, 2, 3, 4, 5 }));
+    }
+
+    [Test]
+    public void ParallelMap_PropagatesErrorsCorrectly()
+    {
+        var stream = Stream.Range(1, 10)
+            .ParallelMap(async x =>
+            {
+                if (x == 5) throw new InvalidOperationException("Boom");
+                await Task.Yield();
+                return x;
+            }, maxConcurrency: 2);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await stream.ToListAsync());
+    }
+
+    [Test]
+    public void ParallelMapOrdered_PropagatesErrorsCorrectly()
+    {
+        var stream = Stream.Range(1, 10)
+            .ParallelMapOrdered(async x =>
+            {
+                if (x == 5) throw new InvalidOperationException("Boom");
+                await Task.Yield();
+                return x;
+            }, maxConcurrency: 2);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await stream.ToListAsync());
+    }
 }

--- a/src/Streamix.Tests/ResourceSafetyTests.cs
+++ b/src/Streamix.Tests/ResourceSafetyTests.cs
@@ -184,4 +184,84 @@ public class ResourceSafetyTests
 
         Assert.That(source.DisposeCount, Is.EqualTo(1), "Source should be disposed now");
     }
+
+    [Test]
+    public async Task ParallelMap_CancelsOutstandingTasks_OnCancellation()
+    {
+        var taskStarted = 0;
+        var taskCancelled = 0;
+
+        var cts = new CancellationTokenSource();
+        var stream = Stream.Range(1, 10)
+            .ParallelMap(async x =>
+            {
+                Interlocked.Increment(ref taskStarted);
+                try
+                {
+                    await Task.Delay(1000, cts.Token);
+                    return x;
+                }
+                catch (OperationCanceledException)
+                {
+                    Interlocked.Increment(ref taskCancelled);
+                    throw;
+                }
+            }, maxConcurrency: 5);
+
+        var enumerator = stream.GetAsyncEnumerator(cts.Token);
+        var moveNextTask = enumerator.MoveNextAsync();
+
+        // Give some time for producer to start tasks
+        await Task.Delay(200);
+
+        await cts.CancelAsync();
+        try { await moveNextTask; } catch (OperationCanceledException) { }
+        await enumerator.DisposeAsync();
+
+        // Wait for background tasks to settle
+        await Task.Delay(500);
+
+        Assert.That(taskStarted, Is.GreaterThan(0));
+        Assert.That(taskCancelled, Is.EqualTo(taskStarted));
+    }
+
+    [Test]
+    public async Task ParallelMapOrdered_CancelsOutstandingTasks_OnCancellation()
+    {
+        var taskStarted = 0;
+        var taskCancelled = 0;
+
+        var cts = new CancellationTokenSource();
+        var stream = Stream.Range(1, 10)
+            .ParallelMapOrdered(async x =>
+            {
+                Interlocked.Increment(ref taskStarted);
+                try
+                {
+                    await Task.Delay(1000, cts.Token);
+                    return x;
+                }
+                catch (OperationCanceledException)
+                {
+                    Interlocked.Increment(ref taskCancelled);
+                    throw;
+                }
+            }, maxConcurrency: 5);
+
+        var enumerator = stream.GetAsyncEnumerator(cts.Token);
+        var moveNextTask = enumerator.MoveNextAsync();
+
+        // Give some time for producer to start tasks
+        await Task.Delay(200);
+
+        await cts.CancelAsync();
+        try { await moveNextTask; } catch (OperationCanceledException) { }
+        await enumerator.DisposeAsync();
+
+        // Wait for background tasks to settle
+        await Task.Delay(500);
+
+        Assert.That(taskStarted, Is.GreaterThan(0));
+        Assert.That(taskCancelled, Is.EqualTo(taskStarted));
+    }
 }

--- a/src/Streamix/Abstractions/IStream.cs
+++ b/src/Streamix/Abstractions/IStream.cs
@@ -82,6 +82,26 @@ public interface IStream<T> : IAsyncEnumerable<T>
     IStream<TResult> FlatMapAwait<TResult>(Func<T, ValueTask<ISingle<TResult>>> selector, int maxConcurrency = 1);
 
     /// <summary>
+    /// Projects each element of a stream into a new form by applying an asynchronous transform function in parallel.
+    /// Elements are emitted as soon as they are ready, so the original order may not be preserved.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the elements in the resulting stream.</typeparam>
+    /// <param name="selector">An asynchronous transform function to apply to each element.</param>
+    /// <param name="maxConcurrency">The maximum number of concurrent operations.</param>
+    /// <returns>An <see cref="IStream{TResult}"/> whose elements are the result of invoking the async transform function on each element of source.</returns>
+    IStream<TResult> ParallelMap<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency);
+
+    /// <summary>
+    /// Projects each element of a stream into a new form by applying an asynchronous transform function in parallel,
+    /// while preserving the original upstream ordering.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the elements in the resulting stream.</typeparam>
+    /// <param name="selector">An asynchronous transform function to apply to each element.</param>
+    /// <param name="maxConcurrency">The maximum number of concurrent operations.</param>
+    /// <returns>An <see cref="IStream{TResult}"/> whose elements are the result of invoking the async transform function on each element of source, in their original order.</returns>
+    IStream<TResult> ParallelMapOrdered<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency);
+
+    /// <summary>
     /// Projects each element of a stream to an <see cref="ISingle{TResult}"/> and flattens the resulting streams into one stream. Alias for <see cref="FlatMap{TResult}(Func{T, ISingle{TResult}}, int)"/>.
     /// </summary>
     /// <typeparam name="TResult">The type of the elements in the resulting stream.</typeparam>

--- a/src/Streamix/Operators/ConnectableStream.cs
+++ b/src/Streamix/Operators/ConnectableStream.cs
@@ -234,6 +234,7 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
             }
             finally
             {
+                try { await Task.WhenAll(tasks); } catch { }
                 semaphore.Dispose();
             }
         }
@@ -373,6 +374,7 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
             }
             finally
             {
+                try { await Task.WhenAll(tasks); } catch { }
                 semaphore.Dispose();
             }
         }, cts.Token);
@@ -382,6 +384,79 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
             while (await channel.Reader.WaitToReadAsync(cancellationToken))
                 while (channel.Reader.TryRead(out var result))
                     yield return result;
+
+            await producerTask;
+            await channel.Reader.Completion;
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await producerTask; } catch { }
+        }
+    }
+
+    async IAsyncEnumerable<TResult> parallelMapOrdered<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (maxConcurrency == 1)
+        {
+            await foreach (var item in this.WithCancellation(cancellationToken))
+                yield return await selector(item);
+            yield break;
+        }
+
+        var channel = Channel.CreateBounded<Task<TResult>>(maxConcurrency);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        var producerTask = Task.Run(async () =>
+        {
+            var semaphore = new SemaphoreSlim(maxConcurrency);
+            var tasks = new List<Task>();
+            try
+            {
+                await foreach (var item in this.WithCancellation(cts.Token))
+                {
+                    await semaphore.WaitAsync(cts.Token);
+
+                    var task = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            return await selector(item);
+                        }
+                        finally
+                        {
+                            semaphore.Release();
+                        }
+                    }, cts.Token);
+
+                    tasks.Add(task);
+                    await channel.Writer.WriteAsync(task, cts.Token);
+                    tasks.RemoveAll(t => t.IsCompleted);
+                }
+
+                await Task.WhenAll(tasks);
+                channel.Writer.Complete();
+            }
+            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
+            {
+                channel.Writer.TryComplete();
+            }
+            catch (Exception ex)
+            {
+                channel.Writer.TryComplete(ex);
+            }
+            finally
+            {
+                try { await Task.WhenAll(tasks); } catch { }
+                semaphore.Dispose();
+            }
+        }, cts.Token);
+
+        try
+        {
+            while (await channel.Reader.WaitToReadAsync(cancellationToken))
+                while (channel.Reader.TryRead(out var task))
+                    yield return await task;
 
             await producerTask;
             await channel.Reader.Completion;
@@ -938,6 +1013,20 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
         return Stream.From(flatMapAwaitConcurrent(selector, maxConcurrency));
+    }
+
+    /// <inheritdoc />
+    public IStream<TResult> ParallelMap<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency)
+    {
+        if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
+        return FlatMap(selector, maxConcurrency);
+    }
+
+    /// <inheritdoc />
+    public IStream<TResult> ParallelMapOrdered<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency)
+    {
+        if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
+        return Stream.From(parallelMapOrdered(selector, maxConcurrency));
     }
 
     /// <inheritdoc />

--- a/src/Streamix/Stream.cs
+++ b/src/Streamix/Stream.cs
@@ -185,6 +185,7 @@ public sealed class Stream<T> : IStream<T>
             }
             finally
             {
+                try { await Task.WhenAll(tasks); } catch { }
                 semaphore.Dispose();
             }
         }, cts.Token);
@@ -207,6 +208,111 @@ public sealed class Stream<T> : IStream<T>
 
                 while (channel.Reader.TryRead(out var result))
                     yield return result;
+            }
+
+            // Wait for producer to complete and check for exceptions
+            await producerTask;
+            await channel.Reader.Completion;
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await producerTask; } catch { }
+        }
+    }
+
+    async IAsyncEnumerable<TResult> parallelMapOrdered<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (maxConcurrency == 1)
+        {
+            await foreach (var item in this.WithCancellation(cancellationToken))
+                yield return await selector(item);
+            yield break;
+        }
+
+        var channel = Channel.CreateBounded<Task<TResult>>(maxConcurrency);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        var producerTask = Task.Run(async () =>
+        {
+            var semaphore = new SemaphoreSlim(maxConcurrency);
+            var tasks = new List<Task>();
+            try
+            {
+                var enumerator = this.WithCancellation(cts.Token).GetAsyncEnumerator();
+                try
+                {
+                    while (true)
+                    {
+                        await semaphore.WaitAsync(cts.Token);
+
+                        if (!await enumerator.MoveNextAsync())
+                        {
+                            semaphore.Release();
+                            break;
+                        }
+
+                        var item = enumerator.Current;
+
+                        var task = Task.Run(async () =>
+                        {
+                            try
+                            {
+                                return await selector(item);
+                            }
+                            finally
+                            {
+                                semaphore.Release();
+                            }
+                        }, cts.Token);
+
+                        tasks.Add(task);
+                        await channel.Writer.WriteAsync(task, cts.Token);
+                        tasks.RemoveAll(t => t.IsCompleted);
+                    }
+                }
+                finally
+                {
+                    await enumerator.DisposeAsync();
+                }
+
+                await Task.WhenAll(tasks);
+                channel.Writer.Complete();
+            }
+            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
+            {
+                channel.Writer.TryComplete();
+            }
+            catch (Exception ex)
+            {
+                channel.Writer.TryComplete(ex);
+            }
+            finally
+            {
+                try { await Task.WhenAll(tasks); } catch { }
+                semaphore.Dispose();
+            }
+        }, cts.Token);
+
+        try
+        {
+            while (true)
+            {
+                bool hasMore;
+                try
+                {
+                    hasMore = await channel.Reader.WaitToReadAsync(cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                if (!hasMore) break;
+
+                while (channel.Reader.TryRead(out var task))
+                    yield return await task;
             }
 
             // Wait for producer to complete and check for exceptions
@@ -300,6 +406,7 @@ public sealed class Stream<T> : IStream<T>
             }
             finally
             {
+                try { await Task.WhenAll(tasks); } catch { }
                 semaphore.Dispose();
             }
         }, cts.Token);
@@ -379,6 +486,7 @@ public sealed class Stream<T> : IStream<T>
             }
             finally
             {
+                try { await Task.WhenAll(tasks); } catch { }
                 semaphore.Dispose();
             }
         }, cts.Token);
@@ -450,6 +558,7 @@ public sealed class Stream<T> : IStream<T>
             }
             finally
             {
+                try { await Task.WhenAll(tasks); } catch { }
                 semaphore.Dispose();
             }
         }, cts.Token);
@@ -824,6 +933,20 @@ public sealed class Stream<T> : IStream<T>
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
         return Stream.From(flatMapAwaitConcurrent(selector, maxConcurrency));
+    }
+
+    /// <inheritdoc />
+    public IStream<TResult> ParallelMap<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency)
+    {
+        if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
+        return FlatMap(selector, maxConcurrency);
+    }
+
+    /// <inheritdoc />
+    public IStream<TResult> ParallelMapOrdered<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency)
+    {
+        if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
+        return Stream.From(parallelMapOrdered(selector, maxConcurrency));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
This PR introduces two new operators to `IStream<T>` for simpler parallel asynchronous transformations:

1. `ParallelMap(selector, maxConcurrency)`: Executes the selector in parallel and emits results as soon as they are ready (unordered).
2. `ParallelMapOrdered(selector, maxConcurrency)`: Executes the selector in parallel but preserves the original upstream ordering in the output stream.

The implementation ensures bounded concurrency and natural backpressure by using `SemaphoreSlim` and bounded `Channel`s. 

Additionally, this change includes a critical fix for a race condition in several concurrent operators (including existing `FlatMap` variants) where a `SemaphoreSlim` could be disposed while background tasks were still attempting to call `Release()`, leading to `ObjectDisposedException` during cancellation or failure. These operators now correctly await all background tasks in their `finally` blocks before disposing of the semaphore.

Tests were added to `ConcurrencyTests.cs` to verify ordering and concurrency limits, and to `ResourceSafetyTests.cs` to verify proper cancellation of outstanding work.

---
*PR created automatically by Jules for task [11421363424540255300](https://jules.google.com/task/11421363424540255300) started by @khurram-uworx*