### PR TITLE
Add Share() operator as hot-stream ergonomic shortcut

### DIFF
--- a/src/Streamix.Tests/HotStreamTests.cs
+++ b/src/Streamix.Tests/HotStreamTests.cs
@@ -212,4 +212,47 @@ public class HotStreamTests
             Assert.That(results2, Is.EquivalentTo(new[] { 1, 2, 3 }));
         }
     }
+
+    [Test]
+    public async Task Share_IsEquivalentToPublishRefCount()
+    {
+        var started = new TaskCompletionSource();
+        var continueSignal = new TaskCompletionSource();
+        int executionCount = 0;
+
+        async IAsyncEnumerable<int> GenerateItems()
+        {
+            executionCount++;
+            if (!started.Task.IsCompleted)
+                started.SetResult();
+
+            yield return 1;
+            await continueSignal.Task;
+            yield return 2;
+        }
+
+        var source = Stream.From(GenerateItems());
+        var shared = source.Share();
+
+        // First execution with two concurrent subscribers
+        var results1 = new List<int>();
+        var results2 = new List<int>();
+
+        var t1 = shared.ForEachAsync(results1.Add);
+        await started.Task;
+        var t2 = shared.ForEachAsync(results2.Add);
+        continueSignal.SetResult();
+        await Task.WhenAll(t1, t2);
+
+        Assert.That(executionCount, Is.EqualTo(1));
+        Assert.That(results1, Is.EquivalentTo(new[] { 1, 2 }));
+        Assert.That(results2, Is.Not.Empty);
+
+        // Third subscriber after both have disconnected should trigger a new execution
+        var results3 = new List<int>();
+        await shared.ForEachAsync(results3.Add);
+
+        Assert.That(executionCount, Is.EqualTo(2));
+        Assert.That(results3, Is.EquivalentTo(new[] { 1, 2 }));
+    }
 }

--- a/src/Streamix/Abstractions/IStream.cs
+++ b/src/Streamix/Abstractions/IStream.cs
@@ -231,6 +231,12 @@ public interface IStream<T> : IAsyncEnumerable<T>
     IConnectableStream<T> Publish();
 
     /// <summary>
+    /// Shares the source stream among multiple subscribers. This is a shortcut for <c>Publish().RefCount()</c>.
+    /// </summary>
+    /// <returns>An <see cref="IStream{T}"/>.</returns>
+    IStream<T> Share();
+
+    /// <summary>
     /// Executes upstream operations (including source enumeration) on the specified scheduler.
     /// This is equivalent to SubscribeOn in other reactive libraries.
     /// </summary>

--- a/src/Streamix/Operators/ConnectableStream.cs
+++ b/src/Streamix/Operators/ConnectableStream.cs
@@ -1186,6 +1186,9 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
     public IConnectableStream<T> Publish() => this;
 
     /// <inheritdoc />
+    public IStream<T> Share() => RefCount();
+
+    /// <inheritdoc />
     public IStream<T> RunOn(TaskScheduler scheduler)
     {
         return Stream.From(runOn(scheduler));

--- a/src/Streamix/Stream.cs
+++ b/src/Streamix/Stream.cs
@@ -1099,6 +1099,9 @@ public sealed class Stream<T> : IStream<T>
     public IConnectableStream<T> Publish() => new Streamix.Operators.ConnectableStream<T>(this);
 
     /// <inheritdoc />
+    public IStream<T> Share() => Publish().RefCount();
+
+    /// <inheritdoc />
     public IStream<T> RunOn(TaskScheduler scheduler)
     {
         return Stream.From(runOn(scheduler), clock);


### PR DESCRIPTION
This PR adds the `Share()` operator to `IStream<T>`. `Share()` is a common ergonomic shortcut for `Publish().RefCount()`, allowing multiple subscribers to share a single source execution that connects on the first subscriber and disconnects when the last subscriber leaves.

Changes:
- Modified `src/Streamix/Abstractions/IStream.cs` to include the `Share()` method.
- Implemented `Share()` in `src/Streamix/Stream.cs`.
- Implemented `Share()` in `src/Streamix/Operators/ConnectableStream.cs`.
- Added a new test `Share_IsEquivalentToPublishRefCount` in `src/Streamix.Tests/HotStreamTests.cs`.

Verification:
- Ran `dotnet test --filter HotStreamTests` and all 7 tests passed.
- Code review performed and rated as correct.

---
*PR created automatically by Jules for task [10061534171474458729](https://jules.google.com/task/10061534171474458729) started by @khurram-uworx*