### PR TITLE
Add Replay(int bufferSize) hot-stream support

### DIFF
--- a/src/Streamix.Tests/HotStreamTests.cs
+++ b/src/Streamix.Tests/HotStreamTests.cs
@@ -212,4 +212,81 @@ public class HotStreamTests
             Assert.That(results2, Is.EquivalentTo(new[] { 1, 2, 3 }));
         }
     }
+
+    [Test]
+    public async Task Replay_LateSubscriber_ReceivesBufferedItems()
+    {
+        var tcs = new TaskCompletionSource();
+        var source = Stream.From(GenerateItems());
+        var hot = source.Replay(2);
+
+        async IAsyncEnumerable<int> GenerateItems()
+        {
+            yield return 1;
+            yield return 2;
+            yield return 3;
+            await tcs.Task;
+            yield return 4;
+        }
+
+        using (hot.Connect())
+        {
+            // Wait for 1, 2, 3 to be produced
+            await Task.Delay(100);
+
+            var results = new List<int>();
+            var t = hot.ForEachAsync(results.Add);
+
+            tcs.SetResult();
+            await t;
+
+            // Should receive replayed 2, 3 AND new 4
+            Assert.That(results, Is.EqualTo(new[] { 2, 3, 4 }));
+        }
+    }
+
+    [Test]
+    public async Task Replay_LateSubscriber_AfterCompletion_ReceivesBufferedItemsAndCompletes()
+    {
+        var source = Stream.From(new[] { 1, 2, 3 }.ToAsyncEnumerable());
+        var hot = source.Replay(2);
+
+        using (hot.Connect())
+        {
+            // Wait for completion
+            await Task.Delay(100);
+
+            var results = new List<int>();
+            await hot.ForEachAsync(results.Add);
+
+            Assert.That(results, Is.EqualTo(new[] { 2, 3 }));
+        }
+    }
+
+    [Test]
+    public async Task Replay_LateSubscriber_AfterError_ReceivesBufferedItemsAndFails()
+    {
+        var source = Stream.From(GenerateItems());
+        var hot = source.Replay(2);
+
+        async IAsyncEnumerable<int> GenerateItems()
+        {
+            yield return 1;
+            yield return 2;
+            yield return 3;
+            throw new InvalidOperationException("Source failed");
+        }
+
+        using (hot.Connect())
+        {
+            // Wait for error
+            await Task.Delay(100);
+
+            var results = new List<int>();
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await hot.ForEachAsync(results.Add));
+            Assert.That(ex.Message, Is.EqualTo("Source failed"));
+            Assert.That(results, Is.EqualTo(new[] { 2, 3 }));
+        }
+    }
+
 }

--- a/src/Streamix/Abstractions/IStream.cs
+++ b/src/Streamix/Abstractions/IStream.cs
@@ -233,6 +233,13 @@ public interface IStream<T> : IAsyncEnumerable<T>
     IConnectableStream<T> Publish();
 
     /// <summary>
+    /// Shares the source stream among multiple subscribers and replays the last <paramref name="bufferSize"/> items to late subscribers.
+    /// </summary>
+    /// <param name="bufferSize">The number of items to replay.</param>
+    /// <returns>An <see cref="IConnectableStream{T}"/>.</returns>
+    IConnectableStream<T> Replay(int bufferSize);
+
+    /// <summary>
     /// Executes upstream operations (including source enumeration) on the specified scheduler.
     /// This is equivalent to SubscribeOn in other reactive libraries.
     /// </summary>

--- a/src/Streamix/Operators/ConnectableStream.cs
+++ b/src/Streamix/Operators/ConnectableStream.cs
@@ -27,14 +27,20 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
     readonly IStream<T> source;
     readonly ConcurrentDictionary<Guid, Channel<T>> subscribers = new();
     readonly object _lock = new();
+    readonly int bufferSize;
+    readonly Queue<T> replayBuffer = new();
+    bool isCompleted;
+    Exception? error;
     int refCounter = 0;
     CancellationTokenSource? cts;
     Task? connectionTask;
     IDisposable? autoConnection;
 
-    public ConnectableStream(IStream<T> source)
+    public ConnectableStream(IStream<T> source, int bufferSize = 0)
     {
+        if (bufferSize < 0) throw new ArgumentOutOfRangeException(nameof(bufferSize), "Buffer size cannot be negative.");
         this.source = source;
+        this.bufferSize = bufferSize;
     }
 
     async Task runConnectionInternal(CancellationToken token)
@@ -51,9 +57,20 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
             while (await enumerator.MoveNextAsync())
             {
                 var item = enumerator.Current;
-                var subscribers = this.subscribers.Values.ToArray();
 
-                foreach (var subscriber in subscribers)
+                Channel<T>[] currentSubscribers;
+                lock (_lock)
+                {
+                    if (bufferSize > 0)
+                    {
+                        replayBuffer.Enqueue(item);
+                        while (replayBuffer.Count > bufferSize)
+                            replayBuffer.Dequeue();
+                    }
+                    currentSubscribers = this.subscribers.Values.ToArray();
+                }
+
+                foreach (var subscriber in currentSubscribers)
                 {
                     try
                     {
@@ -61,6 +78,11 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
                     }
                     catch { }
                 }
+            }
+
+            lock (_lock)
+            {
+                isCompleted = true;
             }
 
             var finalSubscribers = subscribers.Values.ToArray();
@@ -75,6 +97,12 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
         }
         catch (Exception ex)
         {
+            lock (_lock)
+            {
+                isCompleted = true;
+                error = ex;
+            }
+
             var finalSubscribers = subscribers.Values.ToArray();
             foreach (var subscriber in finalSubscribers)
                 subscriber.Writer.TryComplete(ex);
@@ -997,6 +1025,10 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
             if (connectionTask != null && !connectionTask.IsCompleted)
                 return new ConnectionDisposable(this);
 
+            replayBuffer.Clear();
+            isCompleted = false;
+            error = null;
+
             cts = new CancellationTokenSource();
             var token = cts.Token;
             connectionTask = runConnectionInternal(token);
@@ -1042,7 +1074,24 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
     {
         var id = Guid.NewGuid();
         var channel = Channel.CreateUnbounded<T>();
-        subscribers.TryAdd(id, channel);
+
+        lock (_lock)
+        {
+            foreach (var item in replayBuffer)
+                channel.Writer.TryWrite(item);
+
+            if (isCompleted)
+            {
+                if (error != null)
+                    channel.Writer.TryComplete(error);
+                else
+                    channel.Writer.TryComplete();
+            }
+            else
+            {
+                subscribers.TryAdd(id, channel);
+            }
+        }
 
         try
         {
@@ -1192,6 +1241,9 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
 
     /// <inheritdoc />
     public IConnectableStream<T> Publish() => this;
+
+    /// <inheritdoc />
+    public IConnectableStream<T> Replay(int bufferSize) => new ConnectableStream<T>(this, bufferSize);
 
     /// <inheritdoc />
     public IStream<T> RunOn(TaskScheduler scheduler)

--- a/src/Streamix/Stream.cs
+++ b/src/Streamix/Stream.cs
@@ -1107,6 +1107,9 @@ public sealed class Stream<T> : IStream<T>
     public IConnectableStream<T> Publish() => new Streamix.Operators.ConnectableStream<T>(this);
 
     /// <inheritdoc />
+    public IConnectableStream<T> Replay(int bufferSize) => new Streamix.Operators.ConnectableStream<T>(this, bufferSize);
+
+    /// <inheritdoc />
     public IStream<T> RunOn(TaskScheduler scheduler)
     {
         return Stream.From(runOn(scheduler), clock);


### PR DESCRIPTION
This PR adds the `Replay(int bufferSize)` operator to the Streamix library, providing support for replayable hot streams. 

Key changes include:
- `IStream<T>` interface now includes `Replay(int bufferSize)`.
- `ConnectableStream<T>` was updated to maintain a bounded `replayBuffer` (using `Queue<T>`) and track terminal state (`isCompleted`, `error`). 
- Late subscribers join the stream and immediately receive any items in the `replayBuffer` followed by the terminal state if the stream has already finished.
- Concurrency was addressed by synchronizing access to the buffer and subscriber list within a lock to prevent duplicate items or missing terminal signals.
- `Stream<T>` implementation now provides a factory for creating replayable streams.
- Comprehensive tests were added to `HotStreamTests.cs` to verify late subscriber behavior, buffer bounding, and replaying of both completion and error states. 

All relevant tests passed, and the project builds successfully.

---
*PR created automatically by Jules for task [11953840948927841448](https://jules.google.com/task/11953840948927841448) started by @khurram-uworx*