### PR TITLE
Add Replay(int bufferSize) hot-stream support

### DIFF
--- a/src/Streamix.Tests/HotStreamTests.cs
+++ b/src/Streamix.Tests/HotStreamTests.cs
@@ -212,4 +212,106 @@ public class HotStreamTests
             Assert.That(results2, Is.EquivalentTo(new[] { 1, 2, 3 }));
         }
     }
+
+    [Test]
+    public async Task Replay_LateSubscriber_ReceivesBufferedItems()
+    {
+        var tcs = new TaskCompletionSource();
+        var source = Stream.From(GenerateItems());
+        var hot = source.Replay(2);
+
+        async IAsyncEnumerable<int> GenerateItems()
+        {
+            yield return 1;
+            yield return 2;
+            yield return 3;
+            await tcs.Task;
+            yield return 4;
+        }
+
+        using (hot.Connect())
+        {
+            await Task.Delay(50); // Let first 3 items be produced
+
+            var results = new List<int>();
+            var t = hot.ForEachAsync(results.Add);
+
+            tcs.SetResult();
+            await t;
+
+            // Buffer size is 2, so should receive 2, 3 (buffered) and 4 (new)
+            Assert.That(results, Is.EquivalentTo(new[] { 2, 3, 4 }));
+        }
+    }
+
+    [Test]
+    public async Task Replay_LateSubscriber_ReceivesCompletion()
+    {
+        var source = Stream.From(new[] { 1, 2, 3 }.ToAsyncEnumerable());
+        var hot = source.Replay(2);
+
+        using (hot.Connect())
+        {
+            await Task.Delay(50); // Wait for completion
+
+            var results = new List<int>();
+            await hot.ForEachAsync(results.Add);
+
+            // Should receive last 2 items from buffer
+            Assert.That(results, Is.EquivalentTo(new[] { 2, 3 }));
+        }
+    }
+
+    [Test]
+    public async Task Replay_LateSubscriber_ReceivesError()
+    {
+        var source = Stream.From(GenerateItems());
+        var hot = source.Replay(2);
+
+        async IAsyncEnumerable<int> GenerateItems()
+        {
+            yield return 1;
+            yield return 2;
+            throw new InvalidOperationException("Failed");
+        }
+
+        using (hot.Connect())
+        {
+            await Task.Delay(50); // Wait for failure
+
+            var results = new List<int>();
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await hot.ForEachAsync(results.Add));
+
+            // Should receive buffered items before the error
+            Assert.That(results, Is.EquivalentTo(new[] { 1, 2 }));
+        }
+    }
+
+    [Test]
+    public async Task Replay_RefCount_WorksCorrectly()
+    {
+        int executionCount = 0;
+        var source = Stream.From(GenerateItems());
+        var shared = source.Replay(2).RefCount();
+
+        async IAsyncEnumerable<int> GenerateItems()
+        {
+            executionCount++;
+            yield return 1;
+            yield return 2;
+            yield return 3;
+        }
+
+        var results1 = new List<int>();
+        await shared.ForEachAsync(results1.Add);
+        Assert.That(results1, Is.EquivalentTo(new[] { 1, 2, 3 }));
+
+        // Second subscriber joins after first finished and disconnected
+        // Because RefCount disconnected, it should restart execution, and since it's a new Connect(), buffer is cleared.
+        var results2 = new List<int>();
+        await shared.ForEachAsync(results2.Add);
+
+        Assert.That(executionCount, Is.EqualTo(2));
+        Assert.That(results2, Is.EquivalentTo(new[] { 1, 2, 3 }));
+    }
 }

--- a/src/Streamix/Abstractions/IStream.cs
+++ b/src/Streamix/Abstractions/IStream.cs
@@ -241,6 +241,13 @@ public interface IStream<T> : IAsyncEnumerable<T>
     IConnectableStream<T> Publish();
 
     /// <summary>
+    /// Shares the source stream among multiple subscribers and replays the last <paramref name="bufferSize"/> elements to late subscribers.
+    /// </summary>
+    /// <param name="bufferSize">The maximum number of elements to replay to late subscribers.</param>
+    /// <returns>An <see cref="IConnectableStream{T}"/>.</returns>
+    IConnectableStream<T> Replay(int bufferSize);
+
+    /// <summary>
     /// Executes upstream operations (including source enumeration) on the specified scheduler.
     /// This is equivalent to SubscribeOn in other reactive libraries.
     /// </summary>

--- a/src/Streamix/Operators/ConnectableStream.cs
+++ b/src/Streamix/Operators/ConnectableStream.cs
@@ -28,14 +28,20 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
     readonly IClock clock;
     readonly ConcurrentDictionary<Guid, Channel<T>> subscribers = new();
     readonly object _lock = new();
+    readonly int replayBufferSize;
+    readonly Queue<T> replayBuffer = new();
+    bool isCompleted;
+    Exception? error;
     int refCounter = 0;
     CancellationTokenSource? cts;
     Task? connectionTask;
     IDisposable? autoConnection;
 
-    public ConnectableStream(IStream<T> source, IClock? clock = null)
+    public ConnectableStream(IStream<T> source, int bufferSize = 0, IClock? clock = null)
     {
+        if (bufferSize < 0) throw new ArgumentOutOfRangeException(nameof(bufferSize), "Buffer size must be non-negative.");
         this.source = source;
+        this.replayBufferSize = bufferSize;
         this.clock = clock ?? (source is Stream<T> s ? s.Clock : Streamix.Concurrency.SystemClock.Instance);
     }
 
@@ -53,9 +59,20 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
             while (await enumerator.MoveNextAsync())
             {
                 var item = enumerator.Current;
-                var subscribers = this.subscribers.Values.ToArray();
+                Channel<T>[] currentSubscribers;
 
-                foreach (var subscriber in subscribers)
+                lock (_lock)
+                {
+                    if (replayBufferSize > 0)
+                    {
+                        replayBuffer.Enqueue(item);
+                        while (replayBuffer.Count > replayBufferSize)
+                            replayBuffer.Dequeue();
+                    }
+                    currentSubscribers = this.subscribers.Values.ToArray();
+                }
+
+                foreach (var subscriber in currentSubscribers)
                 {
                     try
                     {
@@ -65,21 +82,34 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
                 }
             }
 
-            var finalSubscribers = subscribers.Values.ToArray();
-            foreach (var subscriber in finalSubscribers)
-                subscriber.Writer.TryComplete();
+            lock (_lock)
+            {
+                isCompleted = true;
+                var finalSubscribers = subscribers.Values.ToArray();
+                foreach (var subscriber in finalSubscribers)
+                    subscriber.Writer.TryComplete();
+            }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            var finalSubscribers = subscribers.Values.ToArray();
-            foreach (var subscriber in finalSubscribers)
-                subscriber.Writer.TryComplete();
+            lock (_lock)
+            {
+                isCompleted = true;
+                var finalSubscribers = subscribers.Values.ToArray();
+                foreach (var subscriber in finalSubscribers)
+                    subscriber.Writer.TryComplete();
+            }
         }
         catch (Exception ex)
         {
-            var finalSubscribers = subscribers.Values.ToArray();
-            foreach (var subscriber in finalSubscribers)
-                subscriber.Writer.TryComplete(ex);
+            lock (_lock)
+            {
+                isCompleted = true;
+                error = ex;
+                var finalSubscribers = subscribers.Values.ToArray();
+                foreach (var subscriber in finalSubscribers)
+                    subscriber.Writer.TryComplete(ex);
+            }
         }
         finally
         {
@@ -181,9 +211,9 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
             {
                 refCounter++;
                 incremented = true;
-                enumerator = this.GetAsyncEnumerator(cancellationToken);
                 if (refCounter == 1)
                     autoConnection = Connect();
+                enumerator = this.GetAsyncEnumerator(cancellationToken);
             }
 
             while (await enumerator.MoveNextAsync())
@@ -1023,6 +1053,10 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
             if (connectionTask != null && !connectionTask.IsCompleted)
                 return new ConnectionDisposable(this);
 
+            replayBuffer.Clear();
+            isCompleted = false;
+            error = null;
+
             cts = new CancellationTokenSource();
             var token = cts.Token;
             connectionTask = runConnectionInternal(token);
@@ -1068,7 +1102,24 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
     {
         var id = Guid.NewGuid();
         var channel = Channel.CreateUnbounded<T>();
-        subscribers.TryAdd(id, channel);
+
+        lock (_lock)
+        {
+            if (replayBufferSize > 0)
+            {
+                foreach (var item in replayBuffer)
+                    channel.Writer.TryWrite(item);
+            }
+
+            if (isCompleted)
+            {
+                channel.Writer.TryComplete(error);
+            }
+            else
+            {
+                subscribers.TryAdd(id, channel);
+            }
+        }
 
         return getAsyncEnumeratorImpl(id, channel, cancellationToken);
     }
@@ -1223,6 +1274,9 @@ sealed class ConnectableStream<T> : IConnectableStream<T>
 
     /// <inheritdoc />
     public IConnectableStream<T> Publish() => this;
+
+    /// <inheritdoc />
+    public IConnectableStream<T> Replay(int bufferSize) => new ConnectableStream<T>(this, bufferSize);
 
     /// <inheritdoc />
     public IStream<T> RunOn(TaskScheduler scheduler)

--- a/src/Streamix/Stream.cs
+++ b/src/Streamix/Stream.cs
@@ -1143,6 +1143,9 @@ public sealed class Stream<T> : IStream<T>
     public IConnectableStream<T> Publish() => new Streamix.Operators.ConnectableStream<T>(this);
 
     /// <inheritdoc />
+    public IConnectableStream<T> Replay(int bufferSize) => new Streamix.Operators.ConnectableStream<T>(this, bufferSize);
+
+    /// <inheritdoc />
     public IStream<T> RunOn(TaskScheduler scheduler)
     {
         return Stream.From(runOn(scheduler), clock);


### PR DESCRIPTION
This change implements the `Replay(int bufferSize)` operator for hot streams in the `Streamix` library. Late subscribers now receive up to `bufferSize` previously emitted items, as well as the terminal state (completion or error) of the stream if it has already finished. The implementation is thread-safe and includes a fix for a race condition in `RefCount`.

---
*PR created automatically by Jules for task [8804696211015772107](https://jules.google.com/task/8804696211015772107) started by @khurram-uworx*