### PR TITLE
Implement Stream.Defer factory method

### DIFF
--- a/src/Streamix.Tests/DeferTests.cs
+++ b/src/Streamix.Tests/DeferTests.cs
@@ -1,0 +1,95 @@
+using NUnit.Framework;
+using Streamix.Abstractions;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Streamix.Tests;
+
+[TestFixture]
+public class DeferTests
+{
+    [Test]
+    public async Task Defer_Factory_Is_Not_Called_Until_Enumeration()
+    {
+        int factoryCalls = 0;
+        var stream = Stream.Defer(() =>
+        {
+            factoryCalls++;
+            return Stream.Range(1, 3);
+        });
+
+        Assert.That(factoryCalls, Is.EqualTo(0));
+
+        await foreach (var _ in stream) { }
+
+        Assert.That(factoryCalls, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Defer_Factory_Is_Called_Once_Per_Subscriber()
+    {
+        int factoryCalls = 0;
+        var stream = Stream.Defer(() =>
+        {
+            factoryCalls++;
+            return Stream.From(factoryCalls);
+        });
+
+        var results1 = await stream.ToListAsync();
+        Assert.That(results1, Is.EqualTo(new[] { 1 }));
+        Assert.That(factoryCalls, Is.EqualTo(1));
+
+        var results2 = await stream.ToListAsync();
+        Assert.That(results2, Is.EqualTo(new[] { 2 }));
+        Assert.That(factoryCalls, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task Defer_Works_With_Retry_Later()
+    {
+        int factoryCalls = 0;
+        var stream = Stream.Defer(() =>
+        {
+            factoryCalls++;
+            if (factoryCalls == 1)
+                return Stream.Error<int>(new System.Exception("Fail first time"));
+            return Stream.From(factoryCalls);
+        });
+
+        var result = await stream.Retry(1).ToListAsync();
+        Assert.That(result, Is.EqualTo(new[] { 2 }));
+        Assert.That(factoryCalls, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task Defer_Overload_Passes_CancellationToken()
+    {
+        CancellationToken capturedToken = default;
+        var stream = Stream.Defer(ct =>
+        {
+            capturedToken = ct;
+            return Stream.Range(1, 3);
+        });
+
+        using var cts = new CancellationTokenSource();
+        await foreach (var item in stream.WithCancellation(cts.Token))
+        {
+            if (item == 1) break;
+        }
+
+        Assert.That(capturedToken.IsCancellationRequested, Is.False);
+        Assert.That(capturedToken, Is.EqualTo(cts.Token));
+    }
+
+    [Test]
+    public async Task Defer_Chains_With_Downstream_Operators()
+    {
+        var stream = Stream.Defer(() => Stream.Range(1, 5))
+            .Filter(x => x % 2 == 0)
+            .Map(x => x * 10);
+
+        var result = await stream.ToListAsync();
+        Assert.That(result, Is.EqualTo(new[] { 20, 40 }));
+    }
+}

--- a/src/Streamix/Stream.cs
+++ b/src/Streamix/Stream.cs
@@ -1323,10 +1323,35 @@ public static class Stream
     /// <param name="resultSelector">The result selector function.</param>
     /// <returns>A zipped stream.</returns>
     public static IStream<TResult> Zip<T1, T2, TResult>(IStream<T1> first, IStream<T2> second, Func<T1, T2, TResult> resultSelector) => Stream<TResult>.Zip(first, second, resultSelector);
+
+    /// <summary>
+    /// Returns a stream that is created by a factory function for each subscriber.
+    /// </summary>
+    /// <typeparam name="T">The type of items in the stream.</typeparam>
+    /// <param name="factory">The factory function to create the stream.</param>
+    /// <returns>A deferred stream.</returns>
+    public static IStream<T> Defer<T>(Func<IStream<T>> factory) => From(AsyncEnumerable.Defer<T>(_ => factory()));
+
+    /// <summary>
+    /// Returns a stream that is created by a factory function for each subscriber, with access to the subscriber's cancellation token.
+    /// </summary>
+    /// <typeparam name="T">The type of items in the stream.</typeparam>
+    /// <param name="factory">The factory function to create the stream.</param>
+    /// <returns>A deferred stream.</returns>
+    public static IStream<T> Defer<T>(Func<CancellationToken, IStream<T>> factory) => From(AsyncEnumerable.Defer<T>(factory));
 }
 
 internal static class AsyncEnumerable
 {
+    public static async IAsyncEnumerable<T> Defer<T>(Func<CancellationToken, IStream<T>> factory, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var source = factory(cancellationToken);
+        await foreach (var item in source.WithCancellation(cancellationToken))
+        {
+            yield return item;
+        }
+    }
+
     public static async IAsyncEnumerable<T> Empty<T>([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         yield break;


### PR DESCRIPTION
Implemented the `Stream.Defer` factory method in the `Streamix` library. This allows for deferred creation of streams until the moment of enumeration, which is essential for certain reactive patterns and ensures that each subscriber gets a fresh instance of the stream.

Key changes:
- Added `Stream.Defer<T>(Func<IStream<T>> factory)` to the static `Stream` class.
- Added `Stream.Defer<T>(Func<CancellationToken, IStream<T>> factory)` to support passing the subscriber's cancellation token to the factory.
- Implemented the underlying logic in the `AsyncEnumerable.Defer` internal helper using an async iterator to guarantee that the factory is only called during `GetAsyncEnumerator`.
- Added a new test file `src/Streamix.Tests/DeferTests.cs` with comprehensive test coverage.

---
*PR created automatically by Jules for task [16420700148682644588](https://jules.google.com/task/16420700148682644588) started by @khurram-uworx*