### PR TITLE
Implement lazy factory methods for Single: From and Defer

### DIFF
--- a/src/Streamix.Tests/SingleFactoryTests.cs
+++ b/src/Streamix.Tests/SingleFactoryTests.cs
@@ -1,0 +1,101 @@
+using NUnit.Framework;
+using Streamix.Abstractions;
+
+namespace Streamix.Tests;
+
+[TestFixture]
+public class SingleFactoryTests
+{
+    [Test]
+    public async Task From_FuncTask_IsLazy()
+    {
+        int count = 0;
+        var single = Single.From(async () =>
+        {
+            count++;
+            await Task.Yield();
+            return 42;
+        });
+
+        Assert.That(count, Is.EqualTo(0));
+
+        var result = await single.ToTask();
+        Assert.That(result, Is.EqualTo(42));
+        Assert.That(count, Is.EqualTo(1));
+
+        var result2 = await single.ToTask();
+        Assert.That(result2, Is.EqualTo(42));
+        Assert.That(count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task From_FuncCTTask_RespectsCancellation()
+    {
+        var cts = new CancellationTokenSource();
+        var single = Single.From(async ct =>
+        {
+            await Task.Delay(1000, ct);
+            return 42;
+        });
+
+        cts.Cancel();
+        Assert.ThrowsAsync<TaskCanceledException>(async () => await single.ToTask(cts.Token));
+    }
+
+    [Test]
+    public void From_FuncTask_PropagatesException()
+    {
+        var single = Single.From<int>(async () =>
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("Boom");
+        });
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await single.ToTask());
+    }
+
+    [Test]
+    public async Task Defer_IsLazyAndInvokedPerSubscription()
+    {
+        int count = 0;
+        var single = Single.Defer(() =>
+        {
+            count++;
+            return Single.From(count);
+        });
+
+        Assert.That(count, Is.EqualTo(0));
+
+        Assert.That(await single.ToTask(), Is.EqualTo(1));
+        Assert.That(count, Is.EqualTo(1));
+
+        Assert.That(await single.ToTask(), Is.EqualTo(2));
+        Assert.That(count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Defer_FactoryException_Propagates()
+    {
+        var single = Single.Defer<int>(() =>
+        {
+            throw new InvalidOperationException("Factory Boom");
+        });
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await single.ToTask());
+    }
+
+    [Test]
+    public async Task Defer_FuncCT_RespectsCancellation()
+    {
+        var single = Single.Defer(ct =>
+        {
+            if (ct.IsCancellationRequested) throw new OperationCanceledException(ct);
+            return Single.From(42);
+        });
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () => await single.ToTask(cts.Token));
+    }
+}

--- a/src/Streamix/Single.cs
+++ b/src/Streamix/Single.cs
@@ -473,6 +473,28 @@ public static class Single
         yield return await task.WaitAsync(ct);
     }
 
+    static async IAsyncEnumerable<TValue> toAsyncEnumerableFromTaskFunc<TValue>(Func<Task<TValue>> taskFactory, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        yield return await taskFactory().WaitAsync(ct);
+    }
+
+    static async IAsyncEnumerable<TValue> toAsyncEnumerableFromTaskFuncWithCt<TValue>(Func<CancellationToken, Task<TValue>> taskFactory, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        yield return await taskFactory(ct).WaitAsync(ct);
+    }
+
+    static async IAsyncEnumerable<TValue> defer<TValue>(Func<ISingle<TValue>> factory, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var item in factory().WithCancellation(ct))
+            yield return item;
+    }
+
+    static async IAsyncEnumerable<TValue> deferWithCt<TValue>(Func<CancellationToken, ISingle<TValue>> factory, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var item in factory(ct).WithCancellation(ct))
+            yield return item;
+    }
+
     /// <summary>
     /// Creates a <see cref="ISingle{T}"/> from an <see cref="IAsyncEnumerable{T}"/>.
     /// </summary>
@@ -503,6 +525,24 @@ public static class Single
     public static ISingle<T> From<T>(Task<T> task) => From(toAsyncEnumerableFromTask(task));
 
     /// <summary>
+    /// Creates a <see cref="ISingle{T}"/> from a function that returns a <see cref="Task{T}"/>.
+    /// The function is invoked lazily when the stream is subscribed to.
+    /// </summary>
+    /// <typeparam name="T">The type of item in the stream.</typeparam>
+    /// <param name="taskFactory">The function to invoke.</param>
+    /// <returns>A single-item stream that emits the result of the task and then completes.</returns>
+    public static ISingle<T> From<T>(Func<Task<T>> taskFactory) => From(toAsyncEnumerableFromTaskFunc(taskFactory));
+
+    /// <summary>
+    /// Creates a <see cref="ISingle{T}"/> from a function that returns a <see cref="Task{T}"/> and accepts a <see cref="CancellationToken"/>.
+    /// The function is invoked lazily when the stream is subscribed to.
+    /// </summary>
+    /// <typeparam name="T">The type of item in the stream.</typeparam>
+    /// <param name="taskFactory">The function to invoke.</param>
+    /// <returns>A single-item stream that emits the result of the task and then completes.</returns>
+    public static ISingle<T> From<T>(Func<CancellationToken, Task<T>> taskFactory) => From(toAsyncEnumerableFromTaskFuncWithCt(taskFactory));
+
+    /// <summary>
     /// Creates an empty <see cref="ISingle{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of item in the stream.</typeparam>
@@ -516,6 +556,24 @@ public static class Single
     /// <param name="exception">The exception to fail with.</param>
     /// <returns>A failing single-item stream.</returns>
     public static ISingle<T> Error<T>(Exception exception) => From(AsyncEnumerableInternal.Error<T>(exception));
+
+    /// <summary>
+    /// Creates a <see cref="ISingle{T}"/> by invoking a factory function for each subscription.
+    /// This is used to defer the creation of the single-item stream until it is subscribed to.
+    /// </summary>
+    /// <typeparam name="T">The type of item in the stream.</typeparam>
+    /// <param name="factory">The factory function to invoke.</param>
+    /// <returns>A single-item stream that is created lazily for each subscriber.</returns>
+    public static ISingle<T> Defer<T>(Func<ISingle<T>> factory) => From(defer(factory));
+
+    /// <summary>
+    /// Creates a <see cref="ISingle{T}"/> by invoking a factory function that accepts a <see cref="CancellationToken"/> for each subscription.
+    /// This is used to defer the creation of the single-item stream until it is subscribed to.
+    /// </summary>
+    /// <typeparam name="T">The type of item in the stream.</typeparam>
+    /// <param name="factory">The factory function to invoke.</param>
+    /// <returns>A single-item stream that is created lazily for each subscriber.</returns>
+    public static ISingle<T> Defer<T>(Func<CancellationToken, ISingle<T>> factory) => From(deferWithCt(factory));
 }
 
 static class AsyncEnumerableInternal


### PR DESCRIPTION
This PR implements the requested lazy factory methods for the `Single` class:
- `Single.From(Func<Task<T>>)` and `Single.From(Func<CancellationToken, Task<T>>)`: These methods allow creating a single-item stream from a task factory that is only invoked when the stream is subscribed to.
- `Single.Defer(Func<ISingle<T>>)` and `Single.Defer(Func<CancellationToken, ISingle<T>>)`: These methods defer the creation of the underlying stream until subscription, ensuring a fresh stream is created for each subscriber.

All methods are implemented using `async IAsyncEnumerable` to guarantee laziness and once-per-subscription invocation. Cancellation tokens are correctly propagated to the factories and respected during task/stream execution. Unit tests have been added to verify these behaviors and ensure no regressions.

---
*PR created automatically by Jules for task [7049795021653411189](https://jules.google.com/task/7049795021653411189) started by @khurram-uworx*