### PR TITLE
Implement Named Metadata Tracking

### DIFF
--- a/docs/DEVX-TASKS.md
+++ b/docs/DEVX-TASKS.md
@@ -11,7 +11,7 @@ Current state:
 
 ## Suggested Execution Order
 
-1. Task 1: Implement `Named` metadata tracking
+1. ✅ Task 1: Implement `Named` metadata tracking
 2. Task 2: Implement `Log` and `Debug` operators
 3. Task 3: Implement `Checkpoint` operator
 4. Task 4: Implement `Trace` operator
@@ -30,7 +30,7 @@ Current state:
   - `src/Streamix/Implementations/Single.cs`
   - `src/Streamix.Tests/DiagnosticOperatorTests.cs`
 
-## Task 1: Implement `Named` Metadata Tracking
+## Task 1: Implement `Named` Metadata Tracking ✅
 
 ### Priority
 

--- a/src/Streamix.Tests/DevxTests.cs
+++ b/src/Streamix.Tests/DevxTests.cs
@@ -1,0 +1,74 @@
+using NUnit.Framework;
+
+namespace Streamix.Tests;
+
+[TestFixture]
+public class DevxTests
+{
+    [Test]
+    public void Stream_Named_SetsName()
+    {
+        var stream = Stream.Range(1, 5).Named("MyStream");
+        Assert.That(stream.Name, Is.EqualTo("MyStream"));
+    }
+
+    [Test]
+    public void Stream_Name_PropagatesThroughMap()
+    {
+        var stream = Stream.Range(1, 5).Named("MyStream").Map(x => x * 2);
+        Assert.That(stream.Name, Is.EqualTo("MyStream"));
+    }
+
+    [Test]
+    public void Stream_Name_PropagatesThroughFilter()
+    {
+        var stream = Stream.Range(1, 5).Named("MyStream").Filter(x => x % 2 == 0);
+        Assert.That(stream.Name, Is.EqualTo("MyStream"));
+    }
+
+    [Test]
+    public void Stream_Name_PropagatesThroughDoOnNext()
+    {
+        var stream = Stream.Range(1, 5).Named("MyStream").DoOnNext(x => { });
+        Assert.That(stream.Name, Is.EqualTo("MyStream"));
+    }
+
+    [Test]
+    public void Stream_Name_PropagatesThroughPublishAndRefCount()
+    {
+        var source = Stream.Range(1, 5).Named("MyStream");
+        var published = source.Publish();
+        Assert.That(published.Name, Is.EqualTo("MyStream"));
+
+        var refCounted = published.RefCount();
+        Assert.That(refCounted.Name, Is.EqualTo("MyStream"));
+    }
+
+    [Test]
+    public void Single_Named_SetsName()
+    {
+        var single = Single.From(42).Named("MySingle");
+        Assert.That(single.Name, Is.EqualTo("MySingle"));
+    }
+
+    [Test]
+    public void Single_Name_PropagatesThroughMap()
+    {
+        var single = Single.From(42).Named("MySingle").Map(x => x * 2);
+        Assert.That(single.Name, Is.EqualTo("MySingle"));
+    }
+
+    [Test]
+    public void Single_Name_PropagatesThroughDoOnNext()
+    {
+        var single = Single.From(42).Named("MySingle").DoOnNext(x => { });
+        Assert.That(single.Name, Is.EqualTo("MySingle"));
+    }
+
+    [Test]
+    public void Stream_Named_CanBeOverridden()
+    {
+        var stream = Stream.Range(1, 5).Named("Initial").Named("Overridden");
+        Assert.That(stream.Name, Is.EqualTo("Overridden"));
+    }
+}

--- a/src/Streamix/ISingle.cs
+++ b/src/Streamix/ISingle.cs
@@ -9,6 +9,18 @@ namespace Streamix;
 public interface ISingle<T> : IAsyncEnumerable<T>
 {
     /// <summary>
+    /// Gets the name of the single-item stream, if any.
+    /// </summary>
+    string? Name { get; }
+
+    /// <summary>
+    /// Sets the name of the single-item stream.
+    /// </summary>
+    /// <param name="name">The name to set.</param>
+    /// <returns>A new <see cref="ISingle{T}"/> with the specified name.</returns>
+    ISingle<T> Named(string name);
+
+    /// <summary>
     /// Projects the element of a single-item stream into a new form using a synchronous selector function.
     /// </summary>
     /// <typeparam name="TResult">The type of the element in the resulting single-item stream.</typeparam>

--- a/src/Streamix/IStream.cs
+++ b/src/Streamix/IStream.cs
@@ -9,6 +9,18 @@ namespace Streamix;
 public interface IStream<T> : IAsyncEnumerable<T>
 {
     /// <summary>
+    /// Gets the name of the stream, if any.
+    /// </summary>
+    string? Name { get; }
+
+    /// <summary>
+    /// Sets the name of the stream.
+    /// </summary>
+    /// <param name="name">The name to set.</param>
+    /// <returns>A new <see cref="IStream{T}"/> with the specified name.</returns>
+    IStream<T> Named(string name);
+
+    /// <summary>
     /// Projects each element of a stream into a new form using a synchronous selector function.
     /// This overload is sequential and preserves source ordering.
     /// </summary>

--- a/src/Streamix/Implementations/ConnectableStream.cs
+++ b/src/Streamix/Implementations/ConnectableStream.cs
@@ -25,6 +25,7 @@ class ConnectableStream<T> : IConnectableStream<T>
 
     readonly IStream<T> source;
     readonly IClock clock;
+    readonly string? name;
     readonly ConcurrentDictionary<Guid, Channel<T>> subscribers = new();
     readonly object _lock = new();
     readonly int replayBufferSize;
@@ -37,15 +38,25 @@ class ConnectableStream<T> : IConnectableStream<T>
     IDisposable? autoConnection;
     TaskCompletionSource<bool>? refCountDisconnectedTcs;
 
-    public ConnectableStream(IStream<T> source, int bufferSize = 0, IClock? clock = null)
+    public ConnectableStream(IStream<T> source, int bufferSize = 0, IClock? clock = null, string? name = null)
     {
         if (bufferSize < 0) throw new ArgumentOutOfRangeException(nameof(bufferSize), "Buffer size must be non-negative.");
         this.source = source;
         this.replayBufferSize = bufferSize;
         this.clock = clock ?? (source is Stream<T> s ? s.Clock : Streamix.Implementations.SystemClock.Instance);
+        this.name = name ?? source.Name;
     }
 
     internal IClock Clock => clock;
+
+    /// <inheritdoc />
+    public string? Name => name;
+
+    /// <inheritdoc />
+    public IStream<T> Named(string name)
+    {
+        return new ConnectableStream<T>(source, replayBufferSize, clock, name);
+    }
 
     async Task runConnectionInternal(CancellationToken token)
     {
@@ -1594,37 +1605,37 @@ class ConnectableStream<T> : IConnectableStream<T>
     public IStream<T> OnBackpressureBuffer(int capacity)
     {
         if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be greater than 0.");
-        return Streamix.Stream.From(onBackpressureBuffer(capacity), clock);
+        return Streamix.Stream.From(onBackpressureBuffer(capacity), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> OnBackpressureDrop()
     {
-        return Streamix.Stream.From(onBackpressureDrop(), clock);
+        return Streamix.Stream.From(onBackpressureDrop(), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> OnBackpressureLatest()
     {
-        return Streamix.Stream.From(onBackpressureLatest(), clock);
+        return Streamix.Stream.From(onBackpressureLatest(), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> OnBackpressureError()
     {
-        return Streamix.Stream.From(onBackpressureError(), clock);
+        return Streamix.Stream.From(onBackpressureError(), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> Retry(int retryCount, Func<int, Exception, TimeSpan> backoffStrategy)
     {
-        return Stream.From(retry(retryCount, backoffStrategy), clock);
+        return Stream.From(retry(retryCount, backoffStrategy), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> MapAwait<TResult>(Func<T, ValueTask<TResult>> selector)
     {
-        return Stream.From(mapAwait(selector), clock);
+        return Stream.From(mapAwait(selector), clock, name);
     }
 
     /// <inheritdoc />
@@ -1649,34 +1660,34 @@ class ConnectableStream<T> : IConnectableStream<T>
     /// <inheritdoc />
     public IStream<T> FilterAwait(Func<T, ValueTask<bool>> predicate)
     {
-        return Stream.From(filterAwait(predicate), clock);
+        return Stream.From(filterAwait(predicate), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> RefCount()
     {
-        return Stream.From(refCount(), clock);
+        return Stream.From(refCount(), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> FlatMapAwait<TResult>(Func<T, ValueTask<ISingle<TResult>>> selector, int maxConcurrency = int.MaxValue)
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
-        return Stream.From(flatMapAwaitConcurrent(selector, maxConcurrency), clock);
+        return Stream.From(flatMapAwaitConcurrent(selector, maxConcurrency), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> Map<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency = int.MaxValue)
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
-        return Stream.From(parallelMapTask(selector, maxConcurrency), clock);
+        return Stream.From(parallelMapTask(selector, maxConcurrency), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> MapOrdered<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency)
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
-        return Stream.From(parallelMapTaskOrdered(selector, maxConcurrency), clock);
+        return Stream.From(parallelMapTaskOrdered(selector, maxConcurrency), clock, name);
     }
 
     /// <inheritdoc />
@@ -1726,7 +1737,7 @@ class ConnectableStream<T> : IConnectableStream<T>
     /// <inheritdoc />
     public IStream<TResult> Map<TResult>(Func<T, TResult> selector)
     {
-        return Stream.From(map(selector), clock);
+        return Stream.From(map(selector), clock, name);
     }
 
     /// <inheritdoc />
@@ -1735,7 +1746,7 @@ class ConnectableStream<T> : IConnectableStream<T>
     /// <inheritdoc />
     public IStream<T> Filter(Func<T, bool> predicate)
     {
-        return Stream.From(filter(predicate), clock);
+        return Stream.From(filter(predicate), clock, name);
     }
 
     /// <inheritdoc />
@@ -1746,8 +1757,8 @@ class ConnectableStream<T> : IConnectableStream<T>
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
         return maxConcurrency == 1
-            ? Stream.From(flatMap(selector), clock)
-            : Stream.From(parallelMapEnumerable(selector, maxConcurrency), clock);
+            ? Stream.From(flatMap(selector), clock, name)
+            : Stream.From(parallelMapEnumerable(selector, maxConcurrency), clock, name);
     }
 
     /// <inheritdoc />
@@ -1755,8 +1766,8 @@ class ConnectableStream<T> : IConnectableStream<T>
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
         return maxConcurrency == 1
-            ? Stream.From(parallelMapTask(selector, 1), clock)
-            : Stream.From(parallelMapTask(selector, maxConcurrency), clock);
+            ? Stream.From(parallelMapTask(selector, 1), clock, name)
+            : Stream.From(parallelMapTask(selector, maxConcurrency), clock, name);
     }
 
     /// <inheritdoc />
@@ -1767,14 +1778,14 @@ class ConnectableStream<T> : IConnectableStream<T>
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
         return maxConcurrency == 1
-            ? Stream.From(concatMapInternal(selector), clock)
-            : Stream.From(parallelMapEnumerable(selector, maxConcurrency), clock);
+            ? Stream.From(concatMapInternal(selector), clock, name)
+            : Stream.From(parallelMapEnumerable(selector, maxConcurrency), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> ConcatMap<TResult>(Func<T, IStream<TResult>> selector)
     {
-        return Stream.From(concatMapInternal(selector), clock);
+        return Stream.From(concatMapInternal(selector), clock, name);
     }
 
     /// <inheritdoc />
@@ -1782,37 +1793,37 @@ class ConnectableStream<T> : IConnectableStream<T>
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
         if (maxBufferedItemsPerInner <= 0) throw new ArgumentOutOfRangeException(nameof(maxBufferedItemsPerInner), "Max buffered items per inner must be greater than 0.");
-        return Stream.From(flatMapOrdered(selector, maxConcurrency, maxBufferedItemsPerInner), clock);
+        return Stream.From(flatMapOrdered(selector, maxConcurrency, maxBufferedItemsPerInner), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> Take(int count)
     {
-        return Stream.From(take(count), clock);
+        return Stream.From(take(count), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> Skip(int count)
     {
-        return Stream.From(skip(count), clock);
+        return Stream.From(skip(count), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> MergeWith(params IStream<T>[] others)
     {
-        return Stream.From(mergeWith(others), clock);
+        return Stream.From(mergeWith(others), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> ZipWith<TOther, TResult>(IStream<TOther> other, Func<T, TOther, TResult> resultSelector)
     {
-        return Stream.From(zipWith(other, resultSelector), clock);
+        return Stream.From(zipWith(other, resultSelector), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<IList<T>> Buffer(int count)
     {
-        return Stream.From(buffer(count), clock);
+        return Stream.From(buffer(count), clock, name);
     }
 
     /// <inheritdoc />
@@ -1825,7 +1836,7 @@ class ConnectableStream<T> : IConnectableStream<T>
     /// <inheritdoc />
     public IStream<IStream<T>> Window(int count)
     {
-        return Stream.From(window(count), clock);
+        return Stream.From(window(count), clock, name);
     }
 
     /// <inheritdoc />
@@ -1838,43 +1849,43 @@ class ConnectableStream<T> : IConnectableStream<T>
     /// <inheritdoc />
     public IStream<T> Throttle(TimeSpan interval)
     {
-        return Stream.From(throttle(interval), clock);
+        return Stream.From(throttle(interval), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> Delay(TimeSpan interval)
     {
-        return Stream.From(delay(interval), clock);
+        return Stream.From(delay(interval), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> Retry(int retryCount = 1)
     {
-        return Stream.From(retry(retryCount), clock);
+        return Stream.From(retry(retryCount), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> Timeout(TimeSpan interval)
     {
-        return Stream.From(timeout(interval), clock);
+        return Stream.From(timeout(interval), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> OnErrorResume(Func<Exception, IStream<T>> errorHandler)
     {
-        return Stream.From(onErrorResume(errorHandler), clock);
+        return Stream.From(onErrorResume(errorHandler), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> OnErrorReturn(T value)
     {
-        return Stream.From(onErrorReturn(value), clock);
+        return Stream.From(onErrorReturn(value), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> OnErrorMap(Func<Exception, Exception> mapper)
     {
-        return Stream.From(onErrorMap(mapper), clock);
+        return Stream.From(onErrorMap(mapper), clock, name);
     }
 
     /// <inheritdoc />
@@ -1886,19 +1897,19 @@ class ConnectableStream<T> : IConnectableStream<T>
     /// <inheritdoc />
     public IStream<T> RunOn(TaskScheduler scheduler)
     {
-        return Stream.From(runOn(scheduler), clock);
+        return Stream.From(runOn(scheduler), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> PipeThroughChannel(int capacity, ChannelBackpressureMode mode = ChannelBackpressureMode.Wait)
     {
-        return Stream.From(ChannelExecution.PipeThroughChannel(this, capacity, mode), clock);
+        return Stream.From(ChannelExecution.PipeThroughChannel(this, capacity, mode), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> RunOnChannel(int capacity, int degreeOfParallelism = 1, ChannelBackpressureMode mode = ChannelBackpressureMode.Wait)
     {
-        return Stream.From(ChannelExecution.RunOnChannel(this, capacity, degreeOfParallelism, mode), clock);
+        return Stream.From(ChannelExecution.RunOnChannel(this, capacity, degreeOfParallelism, mode), clock, name);
     }
 
     /// <inheritdoc />
@@ -1916,7 +1927,7 @@ class ConnectableStream<T> : IConnectableStream<T>
     /// <inheritdoc />
     public IStream<T> DoOnNext(Action<T> onNext)
     {
-        return Stream.From(doOnNext(onNext), clock);
+        return Stream.From(doOnNext(onNext), clock, name);
     }
 
     /// <inheritdoc />
@@ -1928,25 +1939,25 @@ class ConnectableStream<T> : IConnectableStream<T>
     /// <inheritdoc />
     public IStream<T> TeeToChannel(ChannelWriter<T> writer, bool completeWriter = false)
     {
-        return Stream.From(teeToChannel(writer, completeWriter), clock);
+        return Stream.From(teeToChannel(writer, completeWriter), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> DoOnError(Action<Exception> onError)
     {
-        return Stream.From(doOnError(onError), clock);
+        return Stream.From(doOnError(onError), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> DoOnComplete(Action onComplete)
     {
-        return Stream.From(doOnComplete(onComplete), clock);
+        return Stream.From(doOnComplete(onComplete), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> DoOnTerminate(Action onTerminate)
     {
-        return Stream.From(doOnTerminate(onTerminate), clock);
+        return Stream.From(doOnTerminate(onTerminate), clock, name);
     }
 
     /// <inheritdoc />

--- a/src/Streamix/Implementations/Single.cs
+++ b/src/Streamix/Implementations/Single.cs
@@ -11,11 +11,13 @@ class Single<T> : ISingle<T>
 {
     readonly IAsyncEnumerable<T> source;
     readonly IClock clock;
+    readonly string? name;
 
-    internal Single(IAsyncEnumerable<T> source, IClock? clock = null)
+    internal Single(IAsyncEnumerable<T> source, IClock? clock = null, string? name = null)
     {
         this.source = source;
         this.clock = clock ?? SystemClock.Instance;
+        this.name = name;
     }
 
     async IAsyncEnumerable<TResult> map<TResult>(Func<T, TResult> selector, [EnumeratorCancellation] CancellationToken ct = default)
@@ -331,6 +333,15 @@ class Single<T> : ISingle<T>
     internal IClock Clock => clock;
 
     /// <inheritdoc />
+    public string? Name => name;
+
+    /// <inheritdoc />
+    public ISingle<T> Named(string name)
+    {
+        return new Single<T>(source, clock, name);
+    }
+
+    /// <inheritdoc />
     public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
     {
         return Single.EnforceAtMostOne(source, cancellationToken).GetAsyncEnumerator(cancellationToken);
@@ -339,25 +350,25 @@ class Single<T> : ISingle<T>
     /// <inheritdoc />
     public ISingle<T> Retry(int retryCount, Func<int, Exception, TimeSpan> backoffStrategy)
     {
-        return Single.From(retry(retryCount, backoffStrategy), clock);
+        return Single.From(retry(retryCount, backoffStrategy), clock, name);
     }
 
     /// <inheritdoc />
     public ISingle<TResult> MapAwait<TResult>(Func<T, ValueTask<TResult>> selector)
     {
-        return new Single<TResult>(mapAwait(selector));
+        return new Single<TResult>(mapAwait(selector), clock, name);
     }
 
     /// <inheritdoc />
     public ISingle<TResult> Map<TResult>(Func<T, TResult> selector)
     {
-        return new Single<TResult>(map(selector));
+        return new Single<TResult>(map(selector), clock, name);
     }
 
     /// <inheritdoc />
     public ISingle<TResult> FlatMapAwait<TResult>(Func<T, ValueTask<ISingle<TResult>>> selector)
     {
-        return new Single<TResult>(flatMapAwait(selector));
+        return new Single<TResult>(flatMapAwait(selector), clock, name);
     }
 
     /// <inheritdoc />
@@ -366,31 +377,31 @@ class Single<T> : ISingle<T>
     /// <inheritdoc />
     public ISingle<TResult> FlatMap<TResult>(Func<T, ISingle<TResult>> selector)
     {
-        return new Single<TResult>(flatMap(selector));
+        return new Single<TResult>(flatMap(selector), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> FlatMap<TResult>(Func<T, IStream<TResult>> selector)
     {
-        return Streamix.Stream.From(concatMapInternal(selector));
+        return Streamix.Stream.From(concatMapInternal(selector), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> FlatMapAwait<TResult>(Func<T, ValueTask<IStream<TResult>>> selector)
     {
-        return Streamix.Stream.From(concatMapAwaitInternal(selector));
+        return Streamix.Stream.From(concatMapAwaitInternal(selector), clock, name);
     }
 
     /// <inheritdoc />
     public ISingle<T> OnErrorResume(Func<Exception, ISingle<T>> errorHandler)
     {
-        return new Single<T>(onErrorResume(errorHandler));
+        return new Single<T>(onErrorResume(errorHandler), clock, name);
     }
 
     /// <inheritdoc />
     public ISingle<T> OnErrorReturn(T value)
     {
-        return OnErrorResume(_ => Single.From(value));
+        return OnErrorResume(_ => Single.Just<T>(value).Named(name ?? ""));
     }
 
     /// <inheritdoc />
@@ -402,7 +413,7 @@ class Single<T> : ISingle<T>
     /// <inheritdoc />
     public ISingle<T> RunOn(TaskScheduler scheduler)
     {
-        return new Single<T>(runOn(scheduler), clock);
+        return new Single<T>(runOn(scheduler), clock, name);
     }
 
     /// <inheritdoc />
@@ -452,19 +463,19 @@ class Single<T> : ISingle<T>
     /// <inheritdoc />
     public ISingle<T> Retry(int retryCount = 1)
     {
-        return Single.From(retry(retryCount), clock);
+        return Single.From(retry(retryCount), clock, name);
     }
 
     /// <inheritdoc />
     public ISingle<T> Timeout(TimeSpan interval)
     {
-        return Single.From(timeout(interval), clock);
+        return Single.From(timeout(interval), clock, name);
     }
 
     /// <inheritdoc />
     public ISingle<T> DoOnNext(Action<T> onNext)
     {
-        return new Single<T>(doOnNext(onNext), clock);
+        return new Single<T>(doOnNext(onNext), clock, name);
     }
 
     /// <inheritdoc />
@@ -476,18 +487,18 @@ class Single<T> : ISingle<T>
     /// <inheritdoc />
     public ISingle<T> DoOnError(Action<Exception> onError)
     {
-        return new Single<T>(doOnError(onError), clock);
+        return new Single<T>(doOnError(onError), clock, name);
     }
 
     /// <inheritdoc />
     public ISingle<T> DoOnComplete(Action onComplete)
     {
-        return new Single<T>(doOnComplete(onComplete), clock);
+        return new Single<T>(doOnComplete(onComplete), clock, name);
     }
 
     /// <inheritdoc />
     public ISingle<T> DoOnTerminate(Action onTerminate)
     {
-        return new Single<T>(doOnTerminate(onTerminate), clock);
+        return new Single<T>(doOnTerminate(onTerminate), clock, name);
     }
 }

--- a/src/Streamix/Implementations/Stream.cs
+++ b/src/Streamix/Implementations/Stream.cs
@@ -72,11 +72,13 @@ class Stream<T> : IStream<T>
 
     readonly IAsyncEnumerable<T> source;
     readonly IClock clock;
+    readonly string? name;
 
-    internal Stream(IAsyncEnumerable<T> source, IClock? clock = null)
+    internal Stream(IAsyncEnumerable<T> source, IClock? clock = null, string? name = null)
     {
         this.source = source;
         this.clock = clock ?? SystemClock.Instance;
+        this.name = name;
     }
 
     async IAsyncEnumerable<TResult> map<TResult>(Func<T, TResult> selector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -1497,6 +1499,15 @@ class Stream<T> : IStream<T>
     internal IClock Clock => clock;
 
     /// <inheritdoc />
+    public string? Name => name;
+
+    /// <inheritdoc />
+    public IStream<T> Named(string name)
+    {
+        return new Stream<T>(source, clock, name);
+    }
+
+    /// <inheritdoc />
     public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
     {
         return source.GetAsyncEnumerator(cancellationToken);
@@ -1506,49 +1517,49 @@ class Stream<T> : IStream<T>
     public IStream<T> OnBackpressureBuffer(int capacity)
     {
         if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be greater than 0.");
-        return Streamix.Stream.From(onBackpressureBuffer(capacity), clock);
+        return Streamix.Stream.From(onBackpressureBuffer(capacity), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> OnBackpressureDrop()
     {
-        return Streamix.Stream.From(onBackpressureDrop(), clock);
+        return Streamix.Stream.From(onBackpressureDrop(), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> OnBackpressureLatest()
     {
-        return Streamix.Stream.From(onBackpressureLatest(), clock);
+        return Streamix.Stream.From(onBackpressureLatest(), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> OnBackpressureError()
     {
-        return Streamix.Stream.From(onBackpressureError(), clock);
+        return Streamix.Stream.From(onBackpressureError(), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> Retry(int retryCount, Func<int, Exception, TimeSpan> backoffStrategy)
     {
-        return Stream.From(retry(retryCount, backoffStrategy), clock);
+        return Stream.From(retry(retryCount, backoffStrategy), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> MapAwait<TResult>(Func<T, ValueTask<TResult>> selector)
     {
-        return Stream.From(mapAwait(selector));
+        return Stream.From(mapAwait(selector), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> Map<TResult>(Func<T, TResult> selector)
     {
-        return Stream.From(map(selector));
+        return Stream.From(map(selector), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> FilterAwait(Func<T, ValueTask<bool>> predicate)
     {
-        return Stream.From(filterAwait(predicate));
+        return Stream.From(filterAwait(predicate), clock, name);
     }
 
     /// <inheritdoc />
@@ -1557,28 +1568,28 @@ class Stream<T> : IStream<T>
     /// <inheritdoc />
     public IStream<T> Filter(Func<T, bool> predicate)
     {
-        return Stream.From(filter(predicate));
+        return Stream.From(filter(predicate), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> FlatMapAwait<TResult>(Func<T, ValueTask<ISingle<TResult>>> selector, int maxConcurrency = int.MaxValue)
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
-        return Stream.From(flatMapAwaitConcurrent(selector, maxConcurrency));
+        return Stream.From(flatMapAwaitConcurrent(selector, maxConcurrency), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> Map<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency = int.MaxValue)
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
-        return Stream.From(parallelMapTask(selector, maxConcurrency));
+        return Stream.From(parallelMapTask(selector, maxConcurrency), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> MapOrdered<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency)
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
-        return Stream.From(parallelMapTaskOrdered(selector, maxConcurrency));
+        return Stream.From(parallelMapTaskOrdered(selector, maxConcurrency), clock, name);
     }
 
     /// <inheritdoc />
@@ -1589,15 +1600,15 @@ class Stream<T> : IStream<T>
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
         return maxConcurrency == 1
-            ? Stream.From(flatMap(selector))
-            : Stream.From(parallelMapEnumerable(selector, maxConcurrency));
+            ? Stream.From(flatMap(selector), clock, name)
+            : Stream.From(parallelMapEnumerable(selector, maxConcurrency), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> FlatMap<TResult>(Func<T, Task<TResult>> selector, int maxConcurrency = int.MaxValue)
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
-        return Stream.From(parallelMapTask(selector, maxConcurrency));
+        return Stream.From(parallelMapTask(selector, maxConcurrency), clock, name);
     }
 
     /// <inheritdoc />
@@ -1608,14 +1619,14 @@ class Stream<T> : IStream<T>
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
         return maxConcurrency == 1
-            ? Stream.From(concatMapInternal(selector))
-            : Stream.From(parallelMapEnumerable(selector, maxConcurrency));
+            ? Stream.From(concatMapInternal(selector), clock, name)
+            : Stream.From(parallelMapEnumerable(selector, maxConcurrency), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<TResult> ConcatMap<TResult>(Func<T, IStream<TResult>> selector)
     {
-        return Stream.From(concatMapInternal(selector));
+        return Stream.From(concatMapInternal(selector), clock, name);
     }
 
     /// <inheritdoc />
@@ -1623,19 +1634,19 @@ class Stream<T> : IStream<T>
     {
         if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "Max concurrency must be greater than 0.");
         if (maxBufferedItemsPerInner <= 0) throw new ArgumentOutOfRangeException(nameof(maxBufferedItemsPerInner), "Max buffered items per inner must be greater than 0.");
-        return Stream.From(flatMapOrdered(selector, maxConcurrency, maxBufferedItemsPerInner));
+        return Stream.From(flatMapOrdered(selector, maxConcurrency, maxBufferedItemsPerInner), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> Take(int count)
     {
-        return Stream.From(take(count));
+        return Stream.From(take(count), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> Skip(int count)
     {
-        return Stream.From(skip(count));
+        return Stream.From(skip(count), clock, name);
     }
 
     /// <summary>
@@ -1689,20 +1700,20 @@ class Stream<T> : IStream<T>
         var all = new IStream<T>[others.Length + 1];
         all[0] = this;
         others.CopyTo(all, 1);
-        return Merge(all);
+        return Merge(all).Named(name ?? "");
     }
 
     /// <inheritdoc />
     public IStream<TResult> ZipWith<TOther, TResult>(IStream<TOther> other, Func<T, TOther, TResult> resultSelector)
     {
-        return Zip(this, other, resultSelector);
+        return Zip(this, other, resultSelector).Named(name ?? "");
     }
 
     /// <inheritdoc />
     public IStream<IList<T>> Buffer(int count)
     {
         if (count <= 0) throw new ArgumentOutOfRangeException(nameof(count), "Count must be greater than 0.");
-        return Stream.From(buffer(count));
+        return Stream.From(buffer(count), clock, name);
     }
 
     /// <inheritdoc />
@@ -1716,7 +1727,7 @@ class Stream<T> : IStream<T>
     public IStream<IStream<T>> Window(int count)
     {
         if (count <= 0) throw new ArgumentOutOfRangeException(nameof(count), "Count must be greater than 0.");
-        return Stream.From(window(count));
+        return Stream.From(window(count), clock, name);
     }
 
     /// <inheritdoc />
@@ -1729,43 +1740,43 @@ class Stream<T> : IStream<T>
     /// <inheritdoc />
     public IStream<T> Throttle(TimeSpan interval)
     {
-        return Stream.From(throttle(interval), clock);
+        return Stream.From(throttle(interval), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> Delay(TimeSpan interval)
     {
-        return Stream.From<T>(delay(interval), clock);
+        return Stream.From<T>(delay(interval), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> Retry(int retryCount = 1)
     {
-        return Stream.From(retry(retryCount), clock);
+        return Stream.From(retry(retryCount), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> Timeout(TimeSpan interval)
     {
-        return Stream.From(timeout(interval), clock);
+        return Stream.From(timeout(interval), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> OnErrorResume(Func<Exception, IStream<T>> errorHandler)
     {
-        return Stream.From(onErrorResume(errorHandler));
+        return Stream.From(onErrorResume(errorHandler), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> OnErrorReturn(T value)
     {
-        return OnErrorResume(_ => Streamix.Stream.From(value));
+        return OnErrorResume(_ => Streamix.Stream.Just<T>(value).Named(name ?? ""));
     }
 
     /// <inheritdoc />
     public IStream<T> OnErrorMap(Func<Exception, Exception> mapper)
     {
-        return OnErrorResume(ex => Stream.Error<T>(mapper(ex)));
+        return OnErrorResume(ex => Streamix.Stream.Error<T>(mapper(ex)).Named(name ?? ""));
     }
 
     /// <inheritdoc />
@@ -1777,19 +1788,19 @@ class Stream<T> : IStream<T>
     /// <inheritdoc />
     public IStream<T> RunOn(TaskScheduler scheduler)
     {
-        return Stream.From(runOn(scheduler), clock);
+        return Stream.From(runOn(scheduler), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> PipeThroughChannel(int capacity, ChannelBackpressureMode mode = ChannelBackpressureMode.Wait)
     {
-        return Stream.From(ChannelExecution.PipeThroughChannel(this, capacity, mode), clock);
+        return Stream.From(ChannelExecution.PipeThroughChannel(this, capacity, mode), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> RunOnChannel(int capacity, int degreeOfParallelism = 1, ChannelBackpressureMode mode = ChannelBackpressureMode.Wait)
     {
-        return Stream.From(ChannelExecution.RunOnChannel(this, capacity, degreeOfParallelism, mode), clock);
+        return Stream.From(ChannelExecution.RunOnChannel(this, capacity, degreeOfParallelism, mode), clock, name);
     }
 
     /// <inheritdoc />
@@ -1809,7 +1820,7 @@ class Stream<T> : IStream<T>
     /// <inheritdoc />
     public IStream<T> DoOnNext(Action<T> onNext)
     {
-        return Stream.From(doOnNext(onNext), clock);
+        return Stream.From(doOnNext(onNext), clock, name);
     }
 
     /// <inheritdoc />
@@ -1821,25 +1832,25 @@ class Stream<T> : IStream<T>
     /// <inheritdoc />
     public IStream<T> TeeToChannel(ChannelWriter<T> writer, bool completeWriter = false)
     {
-        return Stream.From(teeToChannel(writer, completeWriter), clock);
+        return Stream.From(teeToChannel(writer, completeWriter), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> DoOnError(Action<Exception> onError)
     {
-        return Stream.From(doOnError(onError), clock);
+        return Stream.From(doOnError(onError), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> DoOnComplete(Action onComplete)
     {
-        return Stream.From(doOnComplete(onComplete), clock);
+        return Stream.From(doOnComplete(onComplete), clock, name);
     }
 
     /// <inheritdoc />
     public IStream<T> DoOnTerminate(Action onTerminate)
     {
-        return Stream.From(doOnTerminate(onTerminate), clock);
+        return Stream.From(doOnTerminate(onTerminate), clock, name);
     }
 
     /// <inheritdoc />

--- a/src/Streamix/Single.cs
+++ b/src/Streamix/Single.cs
@@ -89,9 +89,27 @@ public static class Single
     public static ISingle<T> From<T>(IAsyncEnumerable<T> source) => new Single<T>(source);
 
     /// <summary>
+    /// Creates a <see cref="ISingle{T}"/> from an <see cref="IAsyncEnumerable{T}"/> and name.
+    /// </summary>
+    /// <typeparam name="T">The type of item in the stream.</typeparam>
+    /// <param name="source">The source asynchronous enumerable.</param>
+    /// <param name="name">The name of the single-item stream.</param>
+    /// <returns>A single-item stream wrapping the source.</returns>
+    public static ISingle<T> From<T>(IAsyncEnumerable<T> source, string? name)
+    {
+        if (source is ISingle<T> single && single.Name == name) return single;
+        return new Single<T>(source, null, name);
+    }
+
+    /// <summary>
     /// Creates a <see cref="ISingle{T}"/> from an <see cref="IAsyncEnumerable{T}"/> with a specific clock.
     /// </summary>
     public static ISingle<T> From<T>(IAsyncEnumerable<T> source, IClock clock) => new Single<T>(source, clock);
+
+    /// <summary>
+    /// Creates a <see cref="ISingle{T}"/> from an <see cref="IAsyncEnumerable{T}"/> with a specific clock and name.
+    /// </summary>
+    public static ISingle<T> From<T>(IAsyncEnumerable<T> source, IClock clock, string? name) => new Single<T>(source, clock, name);
 
     /// <summary>
     /// Creates a <see cref="ISingle{T}"/> from a single value.

--- a/src/Streamix/Stream.cs
+++ b/src/Streamix/Stream.cs
@@ -221,6 +221,11 @@ public static class Stream
     public static IStream<T> From<T>(IAsyncEnumerable<T> source, IClock clock) => new Stream<T>(source, clock);
 
     /// <summary>
+    /// Creates a stream from an <see cref="IAsyncEnumerable{T}"/>, <see cref="IClock"/> and name.
+    /// </summary>
+    public static IStream<T> From<T>(IAsyncEnumerable<T> source, IClock clock, string? name) => new Stream<T>(source, clock, name);
+
+    /// <summary>
     /// Creates a stream from an <see cref="IAsyncEnumerable{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of items in the stream.</typeparam>
@@ -230,6 +235,19 @@ public static class Stream
     {
         if (source is IStream<T> stream) return stream;
         return new Stream<T>(source);
+    }
+
+    /// <summary>
+    /// Creates a stream from an <see cref="IAsyncEnumerable{T}"/> and name.
+    /// </summary>
+    /// <typeparam name="T">The type of items in the stream.</typeparam>
+    /// <param name="source">The source asynchronous enumerable.</param>
+    /// <param name="name">The name of the stream.</param>
+    /// <returns>A stream wrapping the source.</returns>
+    public static IStream<T> From<T>(IAsyncEnumerable<T> source, string? name)
+    {
+        if (source is IStream<T> stream && stream.Name == name) return stream;
+        return new Stream<T>(source, null, name);
     }
 
     /// <summary>


### PR DESCRIPTION
This change implements Task 1 from the DEVX roadmap. It adds a `Name` property and a `Named` operator to both `IStream<T>` and `ISingle<T>`, ensuring that metadata is propagated throughout the pipeline. This provides the foundation for future logging and tracing operators.

---
*PR created automatically by Jules for task [3101666738830128800](https://jules.google.com/task/3101666738830128800) started by @khurram-uworx*