### PR TITLE
Implement Checkpoint Operator for Streams and Singles

### DIFF
--- a/docs/DEVX-TASKS.md
+++ b/docs/DEVX-TASKS.md
@@ -13,7 +13,7 @@ Current state:
 
 1. ✅ Task 1: Implement `Named` metadata tracking
 2. ✅ Task 2: Implement `Log` and `Debug` operators
-3. Task 3: Implement `Checkpoint` operator
+3. ✅ Task 3: Implement `Checkpoint` operator
 4. Task 4: Implement `Trace` operator
 5. Task 5: Add behavioral tests for DEVX operators
 6. Task 6: Update documentation and examples

--- a/src/Streamix.Tests/DiagnosticOperatorTests.cs
+++ b/src/Streamix.Tests/DiagnosticOperatorTests.cs
@@ -313,4 +313,40 @@ public class DiagnosticOperatorTests
         Assert.That(logs, Contains.Item("[TestSingle] Next(42)"));
         Assert.That(logs, Contains.Item("[TestSingle] Completed"));
     }
+
+    [Test]
+    public async Task Stream_Checkpoint_LogsTimingInformation()
+    {
+        var logs = new List<string>();
+        await Stream.Range(1, 2)
+            .Checkpoint("TestCheckpoint", s => logs.Add(s))
+            .DrainAsync();
+
+        Assert.That(logs.Any(l => l.Contains("[Checkpoint: TestCheckpoint] Next(1)") && l.Contains("Total:") && l.Contains("Since last:")), Is.True);
+        Assert.That(logs.Any(l => l.Contains("[Checkpoint: TestCheckpoint] Next(2)") && l.Contains("Total:") && l.Contains("Since last:")), Is.True);
+        Assert.That(logs.Any(l => l.Contains("[Checkpoint: TestCheckpoint] Completed") && l.Contains("Total:")), Is.True);
+    }
+
+    [Test]
+    public void Stream_Checkpoint_LogsErrorTiming()
+    {
+        var logs = new List<string>();
+        var stream = Stream.Error<int>(new Exception("Fail"))
+            .Checkpoint("ErrorCheckpoint", s => logs.Add(s));
+
+        Assert.ThrowsAsync<Exception>(async () => await stream.DrainAsync());
+        Assert.That(logs.Any(l => l.Contains("[Checkpoint: ErrorCheckpoint] Error(Fail)") && l.Contains("Total:")), Is.True);
+    }
+
+    [Test]
+    public async Task Single_Checkpoint_LogsTimingInformation()
+    {
+        var logs = new List<string>();
+        await Single.From(42)
+            .Checkpoint("SingleCheckpoint", s => logs.Add(s))
+            .ToTask();
+
+        Assert.That(logs.Any(l => l.Contains("[Checkpoint: SingleCheckpoint] Next(42)") && l.Contains("Total:")), Is.True);
+        Assert.That(logs.Any(l => l.Contains("[Checkpoint: SingleCheckpoint] Completed") && l.Contains("Total:")), Is.True);
+    }
 }

--- a/src/Streamix/ISingle.cs
+++ b/src/Streamix/ISingle.cs
@@ -194,6 +194,22 @@ public interface ISingle<T> : IAsyncEnumerable<T>
     ISingle<T> Debug(string prefix);
 
     /// <summary>
+    /// Tracks progress through a specific stage of the pipeline with timing information.
+    /// Logs when the item passes through, including time since stream start.
+    /// </summary>
+    /// <param name="checkpointName">The name of the checkpoint.</param>
+    /// <returns>The same single-item stream.</returns>
+    ISingle<T> Checkpoint(string checkpointName);
+
+    /// <summary>
+    /// Tracks progress through a specific stage of the pipeline with timing information using a custom logging action.
+    /// </summary>
+    /// <param name="checkpointName">The name of the checkpoint.</param>
+    /// <param name="loggerAction">The action to use for logging.</param>
+    /// <returns>The same single-item stream.</returns>
+    ISingle<T> Checkpoint(string checkpointName, Action<string> loggerAction);
+
+    /// <summary>
     /// Executes an action for the element of the stream without modifying it.
     /// This operator does not catch exceptions thrown by the action.
     /// </summary>

--- a/src/Streamix/IStream.cs
+++ b/src/Streamix/IStream.cs
@@ -388,6 +388,22 @@ public interface IStream<T> : IAsyncEnumerable<T>
     IStream<T> Debug(string prefix);
 
     /// <summary>
+    /// Tracks progress through a specific stage of the pipeline with timing information.
+    /// Logs when items pass through, including time since stream start and time since last item.
+    /// </summary>
+    /// <param name="checkpointName">The name of the checkpoint.</param>
+    /// <returns>The same stream.</returns>
+    IStream<T> Checkpoint(string checkpointName);
+
+    /// <summary>
+    /// Tracks progress through a specific stage of the pipeline with timing information using a custom logging action.
+    /// </summary>
+    /// <param name="checkpointName">The name of the checkpoint.</param>
+    /// <param name="loggerAction">The action to use for logging.</param>
+    /// <returns>The same stream.</returns>
+    IStream<T> Checkpoint(string checkpointName, Action<string> loggerAction);
+
+    /// <summary>
     /// Executes an action for each element of the stream without modifying it.
     /// This operator does not catch exceptions thrown by the action.
     /// </summary>

--- a/src/Streamix/Implementations/ConnectableStream.cs
+++ b/src/Streamix/Implementations/ConnectableStream.cs
@@ -1582,6 +1582,72 @@ class ConnectableStream<T> : IConnectableStream<T>
         onComplete();
     }
 
+    async IAsyncEnumerable<T> checkpointInternal(string checkpointName, Action<string> logger, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var startTime = clock.Now;
+        var lastItemTime = startTime;
+
+        IAsyncEnumerator<T>? enumerator = null;
+        try
+        {
+            try
+            {
+                enumerator = this.GetAsyncEnumerator(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                var errorTime = clock.Now;
+                var totalErrorElapsed = errorTime - startTime;
+                logger($"[Checkpoint: {checkpointName}] Error({ex.Message}) | Total: {totalErrorElapsed.TotalMilliseconds:F2}ms");
+                throw;
+            }
+
+            while (true)
+            {
+                T item;
+                bool hasNext;
+                try
+                {
+                    hasNext = await enumerator.MoveNextAsync();
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    var cancelTime = clock.Now;
+                    var totalCancelElapsed = cancelTime - startTime;
+                    logger($"[Checkpoint: {checkpointName}] Cancelled | Total: {totalCancelElapsed.TotalMilliseconds:F2}ms");
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    var errorTime = clock.Now;
+                    var totalErrorElapsed = errorTime - startTime;
+                    logger($"[Checkpoint: {checkpointName}] Error({ex.Message}) | Total: {totalErrorElapsed.TotalMilliseconds:F2}ms");
+                    throw;
+                }
+
+                if (!hasNext) break;
+                item = enumerator.Current;
+
+                var now = clock.Now;
+                var totalElapsed = now - startTime;
+                var sinceLastElapsed = now - lastItemTime;
+                lastItemTime = now;
+
+                logger($"[Checkpoint: {checkpointName}] Next({item}) | Total: {totalElapsed.TotalMilliseconds:F2}ms | Since last: {sinceLastElapsed.TotalMilliseconds:F2}ms");
+                yield return item;
+            }
+
+            var completeTime = clock.Now;
+            var totalCompleteElapsed = completeTime - startTime;
+            logger($"[Checkpoint: {checkpointName}] Completed | Total: {totalCompleteElapsed.TotalMilliseconds:F2}ms");
+        }
+        finally
+        {
+            if (enumerator != null)
+                await enumerator.DisposeAsync();
+        }
+    }
+
     async Task forEachAsync(Action<T> action, CancellationToken cancellationToken)
     {
         await foreach (var item in this.WithCancellation(cancellationToken))
@@ -1600,6 +1666,18 @@ class ConnectableStream<T> : IConnectableStream<T>
         {
             cts?.Cancel();
         }
+    }
+
+    /// <inheritdoc />
+    public IStream<T> Checkpoint(string checkpointName)
+    {
+        return Checkpoint(checkpointName, s => Console.WriteLine(s));
+    }
+
+    /// <inheritdoc />
+    public IStream<T> Checkpoint(string checkpointName, Action<string> loggerAction)
+    {
+        return Stream.From(checkpointInternal(checkpointName, loggerAction), clock, name);
     }
 
     /// <inheritdoc />

--- a/src/Streamix/Implementations/Single.cs
+++ b/src/Streamix/Implementations/Single.cs
@@ -331,6 +331,69 @@ class Single<T> : ISingle<T>
         onComplete();
     }
 
+    async IAsyncEnumerable<T> checkpointInternal(string checkpointName, Action<string> logger, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var startTime = clock.Now;
+
+        IAsyncEnumerator<T>? enumerator = null;
+        try
+        {
+            try
+            {
+                enumerator = source.GetAsyncEnumerator(ct);
+            }
+            catch (Exception ex)
+            {
+                var errorTime = clock.Now;
+                var totalErrorElapsed = errorTime - startTime;
+                logger($"[Checkpoint: {checkpointName}] Error({ex.Message}) | Total: {totalErrorElapsed.TotalMilliseconds:F2}ms");
+                throw;
+            }
+
+            while (true)
+            {
+                T item;
+                bool hasNext;
+                try
+                {
+                    hasNext = await enumerator.MoveNextAsync();
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    var cancelTime = clock.Now;
+                    var totalCancelElapsed = cancelTime - startTime;
+                    logger($"[Checkpoint: {checkpointName}] Cancelled | Total: {totalCancelElapsed.TotalMilliseconds:F2}ms");
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    var errorTime = clock.Now;
+                    var totalErrorElapsed = errorTime - startTime;
+                    logger($"[Checkpoint: {checkpointName}] Error({ex.Message}) | Total: {totalErrorElapsed.TotalMilliseconds:F2}ms");
+                    throw;
+                }
+
+                if (!hasNext) break;
+                item = enumerator.Current;
+
+                var now = clock.Now;
+                var totalElapsed = now - startTime;
+
+                logger($"[Checkpoint: {checkpointName}] Next({item}) | Total: {totalElapsed.TotalMilliseconds:F2}ms");
+                yield return item;
+            }
+
+            var completeTime = clock.Now;
+            var totalCompleteElapsed = completeTime - startTime;
+            logger($"[Checkpoint: {checkpointName}] Completed | Total: {totalCompleteElapsed.TotalMilliseconds:F2}ms");
+        }
+        finally
+        {
+            if (enumerator != null)
+                await enumerator.DisposeAsync();
+        }
+    }
+
     internal IClock Clock => clock;
 
     /// <inheritdoc />
@@ -540,5 +603,17 @@ class Single<T> : ISingle<T>
         return DoOnNext(x => System.Diagnostics.Debug.WriteLine($"{pref}Next({x})"))
               .DoOnError(ex => System.Diagnostics.Debug.WriteLine($"{pref}Error({ex.Message})"))
               .DoOnComplete(() => System.Diagnostics.Debug.WriteLine($"{pref}Completed"));
+    }
+
+    /// <inheritdoc />
+    public ISingle<T> Checkpoint(string checkpointName)
+    {
+        return Checkpoint(checkpointName, s => Console.WriteLine(s));
+    }
+
+    /// <inheritdoc />
+    public ISingle<T> Checkpoint(string checkpointName, Action<string> loggerAction)
+    {
+        return new Single<T>(checkpointInternal(checkpointName, loggerAction), clock, name);
     }
 }

--- a/src/Streamix/Implementations/Stream.cs
+++ b/src/Streamix/Implementations/Stream.cs
@@ -1338,6 +1338,72 @@ class Stream<T> : IStream<T>
         onComplete();
     }
 
+    async IAsyncEnumerable<T> checkpointInternal(string checkpointName, Action<string> logger, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var startTime = clock.Now;
+        var lastItemTime = startTime;
+
+        IAsyncEnumerator<T>? enumerator = null;
+        try
+        {
+            try
+            {
+                enumerator = source.GetAsyncEnumerator(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                var errorTime = clock.Now;
+                var totalErrorElapsed = errorTime - startTime;
+                logger($"[Checkpoint: {checkpointName}] Error({ex.Message}) | Total: {totalErrorElapsed.TotalMilliseconds:F2}ms");
+                throw;
+            }
+
+            while (true)
+            {
+                T item;
+                bool hasNext;
+                try
+                {
+                    hasNext = await enumerator.MoveNextAsync();
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    var cancelTime = clock.Now;
+                    var totalCancelElapsed = cancelTime - startTime;
+                    logger($"[Checkpoint: {checkpointName}] Cancelled | Total: {totalCancelElapsed.TotalMilliseconds:F2}ms");
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    var errorTime = clock.Now;
+                    var totalErrorElapsed = errorTime - startTime;
+                    logger($"[Checkpoint: {checkpointName}] Error({ex.Message}) | Total: {totalErrorElapsed.TotalMilliseconds:F2}ms");
+                    throw;
+                }
+
+                if (!hasNext) break;
+                item = enumerator.Current;
+
+                var now = clock.Now;
+                var totalElapsed = now - startTime;
+                var sinceLastElapsed = now - lastItemTime;
+                lastItemTime = now;
+
+                logger($"[Checkpoint: {checkpointName}] Next({item}) | Total: {totalElapsed.TotalMilliseconds:F2}ms | Since last: {sinceLastElapsed.TotalMilliseconds:F2}ms");
+                yield return item;
+            }
+
+            var completeTime = clock.Now;
+            var totalCompleteElapsed = completeTime - startTime;
+            logger($"[Checkpoint: {checkpointName}] Completed | Total: {totalCompleteElapsed.TotalMilliseconds:F2}ms");
+        }
+        finally
+        {
+            if (enumerator != null)
+                await enumerator.DisposeAsync();
+        }
+    }
+
     static async IAsyncEnumerable<T> create(Func<IStreamEmitter<T>, Task> producer, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var channel = Channel.CreateBounded<T>(1);
@@ -1506,6 +1572,18 @@ class Stream<T> : IStream<T>
     public IStream<T> Named(string name)
     {
         return new Stream<T>(source, clock, name);
+    }
+
+    /// <inheritdoc />
+    public IStream<T> Checkpoint(string checkpointName)
+    {
+        return Checkpoint(checkpointName, s => Console.WriteLine(s));
+    }
+
+    /// <inheritdoc />
+    public IStream<T> Checkpoint(string checkpointName, Action<string> loggerAction)
+    {
+        return Stream.From(checkpointInternal(checkpointName, loggerAction), clock, name);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
This PR implements Task 3 from the Developer Experience (DEVX) roadmap.

The `Checkpoint` operator allows developers to track progress through specific stages of a reactive pipeline. It logs lifecycle events (Next, Error, Completed, Cancelled) along with performance timing information:
- Total elapsed time since the stream/single was subscribed to.
- For streams, the time elapsed since the previous item passed through the checkpoint.

Key changes:
1.  **Interfaces**: Added `Checkpoint` methods to `IStream<T>` and `ISingle<T>`.
2.  **Implementations**: Added `checkpointInternal` and public `Checkpoint` implementations to `Stream<T>`, `Single<T>`, and `ConnectableStream<T>`.
3.  **Compiler Fix**: Restructured the async iterators in these implementations to avoid the CS1626 compiler error ("Cannot yield a value in the body of a try block with a catch clause") by wrapping `MoveNextAsync` calls instead of the entire `foreach` loop.
4.  **Tests**: Added unit tests in `src/Streamix.Tests/DiagnosticOperatorTests.cs` to verify correct logging and timing for various scenarios.
5.  **Documentation**: Marked Task 3 as complete in `docs/DEVX-TASKS.md`.

---
*PR created automatically by Jules for task [15688769570887074304](https://jules.google.com/task/15688769570887074304) started by @khurram-uworx*