### PR TITLE
Implement Trace operator for comprehensive stream observability

### DIFF
--- a/docs/DEVX-TASKS.md
+++ b/docs/DEVX-TASKS.md
@@ -14,7 +14,7 @@ Current state:
 1. ✅ Task 1: Implement `Named` metadata tracking
 2. ✅ Task 2: Implement `Log` and `Debug` operators
 3. ✅ Task 3: Implement `Checkpoint` operator
-4. Task 4: Implement `Trace` operator
+4. ✅ Task 4: Implement `Trace` operator
 5. Task 5: Add behavioral tests for DEVX operators
 6. Task 6: Update documentation and examples
 

--- a/src/Streamix.Tests/DiagnosticOperatorTests.cs
+++ b/src/Streamix.Tests/DiagnosticOperatorTests.cs
@@ -349,4 +349,77 @@ public class DiagnosticOperatorTests
         Assert.That(logs.Any(l => l.Contains("[Checkpoint: SingleCheckpoint] Next(42)") && l.Contains("Total:")), Is.True);
         Assert.That(logs.Any(l => l.Contains("[Checkpoint: SingleCheckpoint] Completed") && l.Contains("Total:")), Is.True);
     }
+
+    [Test]
+    public async Task Stream_Trace_LogsAllLifecycleSignals()
+    {
+        var logs = new List<string>();
+        await Stream.Range(1, 2)
+            .Named("TraceStream")
+            .TraceAction(s => logs.Add(s))
+            .DrainAsync();
+
+        Assert.That(logs[0], Is.EqualTo("[TraceStream] Subscribe"));
+        Assert.That(logs[1], Is.EqualTo("[TraceStream] Request(1)"));
+        Assert.That(logs[2], Is.EqualTo("[TraceStream] Next(1)"));
+        Assert.That(logs[3], Is.EqualTo("[TraceStream] Request(1)"));
+        Assert.That(logs[4], Is.EqualTo("[TraceStream] Next(2)"));
+        Assert.That(logs[5], Is.EqualTo("[TraceStream] Request(1)"));
+        Assert.That(logs[6], Is.EqualTo("[TraceStream] Completed"));
+        Assert.That(logs[7], Is.EqualTo("[TraceStream] Dispose"));
+    }
+
+    [Test]
+    public void Stream_Trace_LogsErrorSignal()
+    {
+        var logs = new List<string>();
+        var stream = Stream.Error<int>(new Exception("TraceFail"))
+            .Named("ErrorTrace")
+            .TraceAction(s => logs.Add(s));
+
+        Assert.ThrowsAsync<Exception>(async () => await stream.DrainAsync());
+
+        Assert.That(logs, Contains.Item("[ErrorTrace] Subscribe"));
+        Assert.That(logs, Contains.Item("[ErrorTrace] Error(TraceFail)"));
+        Assert.That(logs, Contains.Item("[ErrorTrace] Dispose"));
+    }
+
+    [Test]
+    public async Task Single_Trace_LogsAllLifecycleSignals()
+    {
+        var logs = new List<string>();
+        await Single.From(42)
+            .Named("TraceSingle")
+            .TraceAction(s => logs.Add(s))
+            .ToTask();
+
+        Assert.That(logs, Contains.Item("[TraceSingle] Subscribe"));
+        Assert.That(logs, Contains.Item("[TraceSingle] Request(1)"));
+        Assert.That(logs, Contains.Item("[TraceSingle] Next(42)"));
+        Assert.That(logs, Contains.Item("[TraceSingle] Completed"));
+        Assert.That(logs, Contains.Item("[TraceSingle] Dispose"));
+    }
+
+    [Test]
+    public async Task Stream_Trace_LogsCancellation()
+    {
+        var logs = new List<string>();
+        using var cts = new CancellationTokenSource();
+        var stream = Stream.Interval(TimeSpan.FromMilliseconds(10))
+            .TraceAction(s => logs.Add(s));
+
+        var task = Task.Run(async () =>
+        {
+            await foreach (var item in stream.WithCancellation(cts.Token))
+            {
+                if (item == 2) cts.Cancel();
+            }
+        });
+
+        Assert.CatchAsync<OperationCanceledException>(async () => await task);
+
+        Assert.That(logs, Contains.Item("Subscribe"));
+        Assert.That(logs, Contains.Item("Cancelled"));
+        Assert.That(logs, Contains.Item("Dispose"));
+    }
 }

--- a/src/Streamix/ISingle.cs
+++ b/src/Streamix/ISingle.cs
@@ -210,6 +210,35 @@ public interface ISingle<T> : IAsyncEnumerable<T>
     ISingle<T> Checkpoint(string checkpointName, Action<string> loggerAction);
 
     /// <summary>
+    /// Provides a comprehensive trace of every stream signal (Subscribe, Next, Error, Complete, Cancel, Dispose).
+    /// Uses the stream name as a prefix if available.
+    /// </summary>
+    /// <returns>The same single-item stream.</returns>
+    ISingle<T> Trace();
+
+    /// <summary>
+    /// Provides a comprehensive trace of every stream signal with a specified prefix.
+    /// </summary>
+    /// <param name="prefix">The prefix to use in traces.</param>
+    /// <returns>The same single-item stream.</returns>
+    ISingle<T> Trace(string prefix);
+
+    /// <summary>
+    /// Provides a comprehensive trace of every stream signal using a custom logging action.
+    /// </summary>
+    /// <param name="loggerAction">The action to use for logging.</param>
+    /// <returns>The same single-item stream.</returns>
+    ISingle<T> TraceAction(Action<string> loggerAction);
+
+    /// <summary>
+    /// Provides a comprehensive trace of every stream signal using an <see cref="Microsoft.Extensions.Logging.ILogger"/>.
+    /// </summary>
+    /// <param name="logger">The logger to use.</param>
+    /// <param name="prefix">Optional prefix. If not provided, the stream name is used.</param>
+    /// <returns>The same single-item stream.</returns>
+    ISingle<T> Trace(Microsoft.Extensions.Logging.ILogger logger, string? prefix = null);
+
+    /// <summary>
     /// Executes an action for the element of the stream without modifying it.
     /// This operator does not catch exceptions thrown by the action.
     /// </summary>

--- a/src/Streamix/IStream.cs
+++ b/src/Streamix/IStream.cs
@@ -404,6 +404,35 @@ public interface IStream<T> : IAsyncEnumerable<T>
     IStream<T> Checkpoint(string checkpointName, Action<string> loggerAction);
 
     /// <summary>
+    /// Provides a comprehensive trace of every stream signal (Subscribe, Next, Error, Complete, Cancel, Dispose).
+    /// Uses the stream name as a prefix if available.
+    /// </summary>
+    /// <returns>The same stream.</returns>
+    IStream<T> Trace();
+
+    /// <summary>
+    /// Provides a comprehensive trace of every stream signal with a specified prefix.
+    /// </summary>
+    /// <param name="prefix">The prefix to use in traces.</param>
+    /// <returns>The same stream.</returns>
+    IStream<T> Trace(string prefix);
+
+    /// <summary>
+    /// Provides a comprehensive trace of every stream signal using a custom logging action.
+    /// </summary>
+    /// <param name="loggerAction">The action to use for logging.</param>
+    /// <returns>The same stream.</returns>
+    IStream<T> TraceAction(Action<string> loggerAction);
+
+    /// <summary>
+    /// Provides a comprehensive trace of every stream signal using an <see cref="Microsoft.Extensions.Logging.ILogger"/>.
+    /// </summary>
+    /// <param name="logger">The logger to use.</param>
+    /// <param name="prefix">Optional prefix. If not provided, the stream name is used.</param>
+    /// <returns>The same stream.</returns>
+    IStream<T> Trace(Microsoft.Extensions.Logging.ILogger logger, string? prefix = null);
+
+    /// <summary>
     /// Executes an action for each element of the stream without modifying it.
     /// This operator does not catch exceptions thrown by the action.
     /// </summary>

--- a/src/Streamix/Implementations/ConnectableStream.cs
+++ b/src/Streamix/Implementations/ConnectableStream.cs
@@ -1561,6 +1561,63 @@ class ConnectableStream<T> : IConnectableStream<T>
         }
     }
 
+    async IAsyncEnumerable<T> traceInternal(string prefix, Action<string> logger, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var pref = string.IsNullOrEmpty(prefix) ? "" : $"[{prefix}] ";
+        logger($"{pref}Subscribe");
+
+        IAsyncEnumerator<T>? enumerator = null;
+        try
+        {
+            try
+            {
+                enumerator = this.GetAsyncEnumerator(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger($"{pref}Error({ex.Message})");
+                throw;
+            }
+
+            while (true)
+            {
+                logger($"{pref}Request(1)");
+                T item;
+                bool hasNext;
+                try
+                {
+                    hasNext = await enumerator.MoveNextAsync();
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    logger($"{pref}Cancelled");
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger($"{pref}Error({ex.Message})");
+                    throw;
+                }
+
+                if (!hasNext) break;
+                item = enumerator.Current;
+
+                logger($"{pref}Next({item})");
+                yield return item;
+            }
+
+            logger($"{pref}Completed");
+        }
+        finally
+        {
+            if (enumerator != null)
+            {
+                await enumerator.DisposeAsync();
+                logger($"{pref}Dispose");
+            }
+        }
+    }
+
     async IAsyncEnumerable<T> doOnTerminate(Action onTerminate, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         try
@@ -1678,6 +1735,27 @@ class ConnectableStream<T> : IConnectableStream<T>
     public IStream<T> Checkpoint(string checkpointName, Action<string> loggerAction)
     {
         return Stream.From(checkpointInternal(checkpointName, loggerAction), clock, name);
+    }
+
+    /// <inheritdoc />
+    public IStream<T> Trace() => Trace(name ?? "");
+
+    /// <inheritdoc />
+    public IStream<T> Trace(string prefix) => TraceAction(s => Console.WriteLine(s), prefix);
+
+    /// <inheritdoc />
+    public IStream<T> TraceAction(Action<string> loggerAction) => TraceAction(loggerAction, name ?? "");
+
+    private IStream<T> TraceAction(Action<string> loggerAction, string prefix)
+    {
+        return Stream.From(traceInternal(prefix, loggerAction), clock, name);
+    }
+
+    /// <inheritdoc />
+    public IStream<T> Trace(ILogger logger, string? prefix = null)
+    {
+        var pref = prefix ?? name ?? "";
+        return TraceAction(s => logger.LogInformation(s), pref);
     }
 
     /// <inheritdoc />

--- a/src/Streamix/Implementations/Single.cs
+++ b/src/Streamix/Implementations/Single.cs
@@ -308,6 +308,63 @@ class Single<T> : ISingle<T>
         }
     }
 
+    async IAsyncEnumerable<T> traceInternal(string prefix, Action<string> logger, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var pref = string.IsNullOrEmpty(prefix) ? "" : $"[{prefix}] ";
+        logger($"{pref}Subscribe");
+
+        IAsyncEnumerator<T>? enumerator = null;
+        try
+        {
+            try
+            {
+                enumerator = source.GetAsyncEnumerator(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger($"{pref}Error({ex.Message})");
+                throw;
+            }
+
+            while (true)
+            {
+                logger($"{pref}Request(1)");
+                T item;
+                bool hasNext;
+                try
+                {
+                    hasNext = await enumerator.MoveNextAsync();
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    logger($"{pref}Cancelled");
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger($"{pref}Error({ex.Message})");
+                    throw;
+                }
+
+                if (!hasNext) break;
+                item = enumerator.Current;
+
+                logger($"{pref}Next({item})");
+                yield return item;
+            }
+
+            logger($"{pref}Completed");
+        }
+        finally
+        {
+            if (enumerator != null)
+            {
+                await enumerator.DisposeAsync();
+                logger($"{pref}Dispose");
+            }
+        }
+    }
+
     async IAsyncEnumerable<T> doOnTerminate(Action onTerminate, [EnumeratorCancellation] CancellationToken ct = default)
     {
         try
@@ -615,5 +672,26 @@ class Single<T> : ISingle<T>
     public ISingle<T> Checkpoint(string checkpointName, Action<string> loggerAction)
     {
         return new Single<T>(checkpointInternal(checkpointName, loggerAction), clock, name);
+    }
+
+    /// <inheritdoc />
+    public ISingle<T> Trace() => Trace(name ?? "");
+
+    /// <inheritdoc />
+    public ISingle<T> Trace(string prefix) => TraceAction(s => Console.WriteLine(s), prefix);
+
+    /// <inheritdoc />
+    public ISingle<T> TraceAction(Action<string> loggerAction) => TraceAction(loggerAction, name ?? "");
+
+    private ISingle<T> TraceAction(Action<string> loggerAction, string prefix)
+    {
+        return new Single<T>(traceInternal(prefix, loggerAction), clock, name);
+    }
+
+    /// <inheritdoc />
+    public ISingle<T> Trace(ILogger logger, string? prefix = null)
+    {
+        var pref = prefix ?? name ?? "";
+        return TraceAction(s => logger.LogInformation(s), pref);
     }
 }

--- a/src/Streamix/Implementations/Stream.cs
+++ b/src/Streamix/Implementations/Stream.cs
@@ -1317,6 +1317,63 @@ class Stream<T> : IStream<T>
         }
     }
 
+    async IAsyncEnumerable<T> traceInternal(string prefix, Action<string> logger, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var pref = string.IsNullOrEmpty(prefix) ? "" : $"[{prefix}] ";
+        logger($"{pref}Subscribe");
+
+        IAsyncEnumerator<T>? enumerator = null;
+        try
+        {
+            try
+            {
+                enumerator = source.GetAsyncEnumerator(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger($"{pref}Error({ex.Message})");
+                throw;
+            }
+
+            while (true)
+            {
+                logger($"{pref}Request(1)");
+                T item;
+                bool hasNext;
+                try
+                {
+                    hasNext = await enumerator.MoveNextAsync();
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    logger($"{pref}Cancelled");
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger($"{pref}Error({ex.Message})");
+                    throw;
+                }
+
+                if (!hasNext) break;
+                item = enumerator.Current;
+
+                logger($"{pref}Next({item})");
+                yield return item;
+            }
+
+            logger($"{pref}Completed");
+        }
+        finally
+        {
+            if (enumerator != null)
+            {
+                await enumerator.DisposeAsync();
+                logger($"{pref}Dispose");
+            }
+        }
+    }
+
     async IAsyncEnumerable<T> doOnTerminate(Action onTerminate, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         try
@@ -1572,6 +1629,27 @@ class Stream<T> : IStream<T>
     public IStream<T> Named(string name)
     {
         return new Stream<T>(source, clock, name);
+    }
+
+    /// <inheritdoc />
+    public IStream<T> Trace() => Trace(name ?? "");
+
+    /// <inheritdoc />
+    public IStream<T> Trace(string prefix) => TraceAction(s => Console.WriteLine(s), prefix);
+
+    /// <inheritdoc />
+    public IStream<T> TraceAction(Action<string> loggerAction) => TraceAction(loggerAction, name ?? "");
+
+    private IStream<T> TraceAction(Action<string> loggerAction, string prefix)
+    {
+        return Stream.From(traceInternal(prefix, loggerAction), clock, name);
+    }
+
+    /// <inheritdoc />
+    public IStream<T> Trace(ILogger logger, string? prefix = null)
+    {
+        var pref = prefix ?? name ?? "";
+        return TraceAction(s => logger.LogInformation(s), pref);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Implemented the `Trace` operator across all core stream types (`IStream<T>`, `ISingle<T>`, `IConnectableStream<T>`) to provide granular lifecycle observability. This operator logs subscription, item requests, emissions, errors, completion, cancellation, and disposal. Added comprehensive unit tests and updated task tracking documentation.

---
*PR created automatically by Jules for task [13554769556194144548](https://jules.google.com/task/13554769556194144548) started by @khurram-uworx*