### PR TITLE
Implement Timestamped and WindowByTime (tumbling)

### DIFF
--- a/docs/TIMESERIES.md
+++ b/docs/TIMESERIES.md
@@ -204,15 +204,15 @@ await temperatureStream
 # Tasks
 
 ## 1. Core Type
-* [ ] Implement `Timestamped<T>`
-* [ ] Add XML docs
-* [ ] Add basic unit tests
+* [✅] Implement `Timestamped<T>`
+* [✅] Add XML docs
+* [✅] Add basic unit tests
 
 ## 2. WindowByTime – Tumbling
-* [ ] Implement `WindowByTime(duration)` (slide = null)
-* [ ] Channel-based window segmentation
-* [ ] Ensure correct boundary handling `[start, end)`
-* [ ] Add tests:
+* [✅] Implement `WindowByTime(duration)` (slide = null)
+* [✅] Channel-based window segmentation
+* [✅] Ensure correct boundary handling `[start, end)`
+* [✅] Add tests:
 
   * exact boundary alignment
   * partial final window

--- a/src/Streamix.Tests/Extensions/TimeseriesTests.cs
+++ b/src/Streamix.Tests/Extensions/TimeseriesTests.cs
@@ -1,0 +1,145 @@
+using NUnit.Framework;
+using Streamix;
+
+namespace Streamix.Tests.Extensions;
+
+[TestFixture]
+public class TimeseriesTests
+{
+    [Test]
+    public void Timestamped_ShouldHoldValueAndTimestamp()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var ts = new Timestamped<int>(42, now);
+
+        Assert.That(ts.Value, Is.EqualTo(42));
+        Assert.That(ts.Timestamp, Is.EqualTo(now));
+    }
+
+    [Test]
+    public void Timestamped_Create_ShouldCreateInstance()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var ts = Timestamped.Create(42, now);
+
+        Assert.That(ts.Value, Is.EqualTo(42));
+        Assert.That(ts.Timestamp, Is.EqualTo(now));
+    }
+
+    [Test]
+    public void Timestamped_Equality_ShouldWork()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var ts1 = new Timestamped<int>(42, now);
+        var ts2 = new Timestamped<int>(42, now);
+        var ts3 = new Timestamped<int>(43, now);
+
+        Assert.That(ts1, Is.EqualTo(ts2));
+        Assert.That(ts1, Is.Not.EqualTo(ts3));
+    }
+
+    [Test]
+    public async Task WindowByTime_Tumbling_ShouldGroupItemsCorrectly()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(10);
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start.AddMinutes(1)),
+            Timestamped.Create(2, start.AddMinutes(5)),
+            Timestamped.Create(3, start.AddMinutes(11)),
+            Timestamped.Create(4, start.AddMinutes(15)),
+            Timestamped.Create(5, start.AddMinutes(21)),
+        };
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration);
+
+        var windowList = new List<List<Timestamped<int>>>();
+        await foreach (var window in windows)
+        {
+            var list = new List<Timestamped<int>>();
+            await foreach (var item in window)
+            {
+                list.Add(item);
+            }
+            windowList.Add(list);
+        }
+
+        Assert.That(windowList, Has.Count.EqualTo(3));
+        Assert.That(windowList[0].Select(x => x.Value), Is.EquivalentTo(new[] { 1, 2 }));
+        Assert.That(windowList[1].Select(x => x.Value), Is.EquivalentTo(new[] { 3, 4 }));
+        Assert.That(windowList[2].Select(x => x.Value), Is.EquivalentTo(new[] { 5 }));
+    }
+
+    [Test]
+    public async Task WindowByTime_Tumbling_ShouldHandleExactBoundaries()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(10);
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start), // Inclusive
+            Timestamped.Create(2, start.AddMinutes(10)), // Exclusive for first, inclusive for second
+        };
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration);
+
+        var windowList = new List<List<Timestamped<int>>>();
+        await foreach (var window in windows)
+        {
+            var list = new List<Timestamped<int>>();
+            await foreach (var item in window)
+            {
+                list.Add(item);
+            }
+            windowList.Add(list);
+        }
+
+        Assert.That(windowList, Has.Count.EqualTo(2));
+        Assert.That(windowList[0].Select(x => x.Value), Is.EquivalentTo(new[] { 1 }));
+        Assert.That(windowList[1].Select(x => x.Value), Is.EquivalentTo(new[] { 2 }));
+    }
+
+    [Test]
+    public async Task WindowByTime_Tumbling_ShouldHandleEmptyStream()
+    {
+        var source = Stream.Empty<Timestamped<int>>();
+        var windows = source.WindowByTime(TimeSpan.FromMinutes(10));
+
+        var count = 0;
+        await foreach (var window in windows)
+        {
+            count++;
+        }
+
+        Assert.That(count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task WindowByTime_Tumbling_ShouldHandleSingleItem()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var items = new[] { Timestamped.Create(1, start) };
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(TimeSpan.FromMinutes(10));
+
+        var windowList = new List<List<Timestamped<int>>>();
+        await foreach (var window in windows)
+        {
+            var list = new List<Timestamped<int>>();
+            await foreach (var item in window)
+            {
+                list.Add(item);
+            }
+            windowList.Add(list);
+        }
+
+        Assert.That(windowList, Has.Count.EqualTo(1));
+        Assert.That(windowList[0].Select(x => x.Value), Is.EquivalentTo(new[] { 1 }));
+    }
+}

--- a/src/Streamix/Extensions/TimeseriesExtension.cs
+++ b/src/Streamix/Extensions/TimeseriesExtension.cs
@@ -1,0 +1,89 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+
+namespace Streamix;
+
+/// <summary>
+/// Provides time-series extension methods for <see cref="IStream{T}"/>.
+/// </summary>
+public static class TimeseriesExtension
+{
+    /// <summary>
+    /// Groups elements of a stream into windows based on their timestamps.
+    /// Supports both tumbling and sliding windows.
+    /// </summary>
+    /// <typeparam name="T">The type of items in the stream.</typeparam>
+    /// <param name="source">The source stream of timestamped items.</param>
+    /// <param name="duration">The duration of each window.</param>
+    /// <param name="slide">The interval at which windows are started. If null, tumbling windows are used (slide = duration).</param>
+    /// <param name="capacity">The capacity of the buffer for each window.</param>
+    /// <param name="mode">The backpressure mode for each window.</param>
+    /// <returns>A stream of window streams.</returns>
+    public static IStream<IStream<Timestamped<T>>> WindowByTime<T>(
+        this IStream<Timestamped<T>> source,
+        TimeSpan duration,
+        TimeSpan? slide = null,
+        int capacity = 16,
+        ChannelBackpressureMode mode = ChannelBackpressureMode.Wait)
+    {
+        if (duration <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(duration));
+        if (slide.HasValue && slide.Value <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(slide));
+
+        return Stream.Create<IStream<Timestamped<T>>>(async emitter =>
+        {
+            var ct = emitter.CancellationToken;
+            if (slide == null || slide == duration)
+            {
+                // Tumbling window logic
+                Channel<Timestamped<T>>? currentWindowChannel = null;
+                DateTimeOffset? currentWindowEnd = null;
+
+                try
+                {
+                    await foreach (var item in source.WithCancellation(ct))
+                    {
+                        if (currentWindowChannel == null || item.Timestamp >= currentWindowEnd)
+                        {
+                            // Complete previous window
+                            currentWindowChannel?.Writer.TryComplete();
+
+                            // Start new window aligned to duration (using UTC ticks for consistency)
+                            var startTicks = (item.Timestamp.UtcTicks / duration.Ticks) * duration.Ticks;
+                            var start = new DateTimeOffset(startTicks, TimeSpan.Zero);
+                            currentWindowEnd = start + duration;
+
+                            currentWindowChannel = ChannelExecution.CreateChannel<Timestamped<T>>(capacity, mode, singleWriter: true);
+
+                            // Emit the window stream eagerly.
+                            // We use CancellationToken.None here because the window stream completion
+                            // is controlled by the currentWindowChannel.Writer.TryComplete() call.
+                            // This prevents TaskCanceledException when the outer stream completes.
+                            await emitter.EmitAsync(Stream.From(currentWindowChannel.Reader.ReadAllAsync(CancellationToken.None)));
+                        }
+
+                        // Write the item to the current window
+                        await ChannelExecution.WriteAsync(currentWindowChannel!.Writer, item, mode, CancellationToken.None);
+                    }
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // Outer stream was cancelled, stop processing.
+                }
+                catch (Exception ex)
+                {
+                    currentWindowChannel?.Writer.TryComplete(ex);
+                    throw;
+                }
+                finally
+                {
+                    currentWindowChannel?.Writer.TryComplete();
+                }
+            }
+            else
+            {
+                // Sliding window logic (Task 3)
+                throw new NotImplementedException("Sliding windows are not yet implemented.");
+            }
+        });
+    }
+}

--- a/src/Streamix/Records.cs
+++ b/src/Streamix/Records.cs
@@ -81,3 +81,26 @@ public readonly record struct Option<T>
     /// </summary>
     public override string ToString() => HasValue ? $"Some({Value})" : "None";
 }
+
+/// <summary>
+/// Represents a value that has been timestamped.
+/// </summary>
+/// <typeparam name="T">The type of the value.</typeparam>
+public readonly record struct Timestamped<T>(
+    T Value,
+    DateTimeOffset Timestamp);
+
+/// <summary>
+/// Provides static methods for creating timestamped values.
+/// </summary>
+public static class Timestamped
+{
+    /// <summary>
+    /// Creates a new timestamped value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <param name="value">The value.</param>
+    /// <param name="timestamp">The timestamp.</param>
+    /// <returns>A new timestamped value.</returns>
+    public static Timestamped<T> Create<T>(T value, DateTimeOffset timestamp) => new(value, timestamp);
+}


### PR DESCRIPTION
This PR introduces first-class support for time-series processing in Streamix by implementing the `Timestamped<T>` data wrapper and the `WindowByTime` tumbling window operator.

Key changes:
- `Timestamped<T>`: A readonly record struct to pair values with timestamps.
- `WindowByTime`: An extension method on `IStream<Timestamped<T>>` that segments streams into time-based windows. Currently supports tumbling windows with `[start, end)` inclusive/exclusive boundaries aligned to the epoch.
- Unit Tests: New tests covering boundary alignment, partial windows, and empty/single-item streams.
- Docs: Updated `docs/TIMESERIES.md` to reflect completed tasks.

---
*PR created automatically by Jules for task [85466368945215358](https://jules.google.com/task/85466368945215358) started by @khurram-uworx*