### PR TITLE
Implement Sliding Windows for WindowByTime

### DIFF
--- a/docs/TIMESERIES.md
+++ b/docs/TIMESERIES.md
@@ -220,10 +220,10 @@ await temperatureStream
   * single item
 
 ## 3. WindowByTime – Sliding
-* [ ] Extend implementation to support `slide`
-* [ ] Ensure overlapping window correctness
-* [ ] Avoid unbounded memory growth
-* [ ] Add tests:
+* [✅] Extend implementation to support `slide`
+* [✅] Ensure overlapping window correctness
+* [✅] Avoid unbounded memory growth
+* [✅] Add tests:
 
   * overlapping membership
   * dense sliding (slide < duration)

--- a/src/Streamix.Tests/Extensions/TimeseriesTests.cs
+++ b/src/Streamix.Tests/Extensions/TimeseriesTests.cs
@@ -142,4 +142,140 @@ public class TimeseriesTests
         Assert.That(windowList, Has.Count.EqualTo(1));
         Assert.That(windowList[0].Select(x => x.Value), Is.EquivalentTo(new[] { 1 }));
     }
+
+    [Test]
+    public async Task WindowByTime_Sliding_ShouldGroupItemsCorrectly()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(10);
+        var slide = TimeSpan.FromMinutes(5);
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start.AddMinutes(1)),
+            Timestamped.Create(2, start.AddMinutes(6)),
+            Timestamped.Create(3, start.AddMinutes(11)),
+        };
+
+        // Window 1: [0, 10) -> items 1, 2
+        // Window 2: [5, 15) -> items 2, 3
+        // Window 3: [10, 20) -> item 3
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration, slide);
+
+        var windowList = new List<List<Timestamped<int>>>();
+        var tasks = new List<Task>();
+        await foreach (var window in windows)
+        {
+            var w = window;
+            tasks.Add(Task.Run(async () =>
+            {
+                var list = new List<Timestamped<int>>();
+                await foreach (var item in w)
+                {
+                    list.Add(item);
+                }
+                lock (windowList) windowList.Add(list);
+            }));
+        }
+        await Task.WhenAll(tasks);
+
+        windowList = windowList.Where(w => w.Count > 0).OrderBy(w => w[0].Timestamp.UtcTicks).ThenByDescending(w => w.Count).ToList();
+
+        Assert.That(windowList, Has.Count.EqualTo(3));
+        Assert.That(windowList[0].Select(x => x.Value), Is.EquivalentTo(new[] { 1, 2 }));
+        Assert.That(windowList[1].Select(x => x.Value), Is.EquivalentTo(new[] { 2, 3 }));
+        Assert.That(windowList[2].Select(x => x.Value), Is.EquivalentTo(new[] { 3 }));
+    }
+
+    [Test]
+    public async Task WindowByTime_Sliding_SparseSliding_ShouldHaveGaps()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(5);
+        var slide = TimeSpan.FromMinutes(10);
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start.AddMinutes(1)),
+            Timestamped.Create(2, start.AddMinutes(6)), // In gap [5, 10)
+            Timestamped.Create(3, start.AddMinutes(11)),
+        };
+
+        // Window 1: [0, 5) -> item 1
+        // Window 2: [10, 15) -> item 3
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration, slide);
+
+        var windowList = new List<List<Timestamped<int>>>();
+        var tasks = new List<Task>();
+        await foreach (var window in windows)
+        {
+            var w = window;
+            tasks.Add(Task.Run(async () =>
+            {
+                var list = new List<Timestamped<int>>();
+                await foreach (var item in w)
+                {
+                    list.Add(item);
+                }
+                lock (windowList) windowList.Add(list);
+            }));
+        }
+        await Task.WhenAll(tasks);
+
+        windowList = windowList.Where(w => w.Count > 0).OrderBy(w => w[0].Timestamp.UtcTicks).ToList();
+
+        Assert.That(windowList, Has.Count.EqualTo(2));
+        Assert.That(windowList[0].Select(x => x.Value), Is.EquivalentTo(new[] { 1 }));
+        Assert.That(windowList[1].Select(x => x.Value), Is.EquivalentTo(new[] { 3 }));
+    }
+
+    [Test]
+    public async Task WindowByTime_Sliding_ExactBoundaries_ShouldHandleInclusionCorrectly()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(10);
+        var slide = TimeSpan.FromMinutes(5);
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start), // Start of Window 1
+            Timestamped.Create(2, start.AddMinutes(5)), // Start of Window 2, middle of Window 1
+            Timestamped.Create(3, start.AddMinutes(10)), // Start of Window 3, end of Window 1 (exclusive)
+        };
+
+        // Window 1: [0, 10) -> items 1, 2
+        // Window 2: [5, 15) -> items 2, 3
+        // Window 3: [10, 20) -> item 3
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration, slide);
+
+        var windowList = new List<List<Timestamped<int>>>();
+        var tasks = new List<Task>();
+        await foreach (var window in windows)
+        {
+            var w = window;
+            tasks.Add(Task.Run(async () =>
+            {
+                var list = new List<Timestamped<int>>();
+                await foreach (var item in w)
+                {
+                    list.Add(item);
+                }
+                lock (windowList) windowList.Add(list);
+            }));
+        }
+        await Task.WhenAll(tasks);
+
+        windowList = windowList.Where(w => w.Count > 0).OrderBy(w => w[0].Timestamp.UtcTicks).ThenByDescending(w => w.Count).ToList();
+
+        Assert.That(windowList, Has.Count.EqualTo(3));
+        Assert.That(windowList[0].Select(x => x.Value), Is.EquivalentTo(new[] { 1, 2 }));
+        Assert.That(windowList[1].Select(x => x.Value), Is.EquivalentTo(new[] { 2, 3 }));
+        Assert.That(windowList[2].Select(x => x.Value), Is.EquivalentTo(new[] { 3 }));
+    }
 }

--- a/src/Streamix/Extensions/TimeseriesExtension.cs
+++ b/src/Streamix/Extensions/TimeseriesExtension.cs
@@ -82,7 +82,93 @@ public static class TimeseriesExtension
             else
             {
                 // Sliding window logic (Task 3)
-                throw new NotImplementedException("Sliding windows are not yet implemented.");
+                var activeWindows = new SortedDictionary<long, Channel<Timestamped<T>>>();
+                long? firstStartTicks = null;
+
+                try
+                {
+                    await foreach (var item in source.WithCancellation(ct))
+                    {
+                        // Clean up expired windows
+                        // Since source is assumed to be monotonic, we can efficiently remove from the front
+                        while (activeWindows.Count > 0)
+                        {
+                            var first = activeWindows.First();
+                            if (first.Key + duration.Ticks <= item.Timestamp.UtcTicks)
+                            {
+                                first.Value.Writer.TryComplete();
+                                activeWindows.Remove(first.Key);
+                            }
+                            else
+                            {
+                                break;
+                            }
+                        }
+
+                        // Identify and create windows for the current item
+                        // A window starting at S contains T if S <= T < S + duration
+                        // This means S > T - duration and S <= T
+                        // And S must be a multiple of slide
+                        var latestStartTicks = (item.Timestamp.UtcTicks / slide.Value.Ticks) * slide.Value.Ticks;
+                        if (firstStartTicks == null) firstStartTicks = latestStartTicks;
+
+                        var earliestStartTicks = item.Timestamp.UtcTicks - duration.Ticks + 1;
+                        var effectiveMinStart = Math.Max(earliestStartTicks, firstStartTicks.Value);
+
+                        // Identify windows to create (in chronological order)
+                        var startsToCreate = new List<long>();
+                        for (var startTicks = latestStartTicks;
+                             startTicks >= effectiveMinStart;
+                             startTicks -= slide.Value.Ticks)
+                        {
+                            if (!activeWindows.ContainsKey(startTicks))
+                            {
+                                startsToCreate.Add(startTicks);
+                            }
+                        }
+
+                        for (int i = startsToCreate.Count - 1; i >= 0; i--)
+                        {
+                            var s = startsToCreate[i];
+                            var channel = ChannelExecution.CreateChannel<Timestamped<T>>(capacity, mode, singleWriter: true);
+                            activeWindows[s] = channel;
+
+                            // Emit the window stream eagerly.
+                            await emitter.EmitAsync(Stream.From(channel.Reader.ReadAllAsync(CancellationToken.None)));
+                        }
+
+                        // Write the item to all windows it belongs to
+                        for (var startTicks = latestStartTicks;
+                             startTicks >= effectiveMinStart;
+                             startTicks -= slide.Value.Ticks)
+                        {
+                            if (activeWindows.TryGetValue(startTicks, out var channel))
+                            {
+                                await ChannelExecution.WriteAsync(channel.Writer, item, mode, CancellationToken.None);
+                            }
+                        }
+                    }
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // Outer stream was cancelled, stop processing.
+                }
+                catch (Exception ex)
+                {
+                    foreach (var window in activeWindows.Values)
+                    {
+                        window.Writer.TryComplete(ex);
+                    }
+                    throw;
+                }
+                finally
+                {
+                    foreach (var window in activeWindows.Values)
+                    {
+                        window.Writer.TryComplete();
+                    }
+                    activeWindows.Clear();
+                }
             }
         });
     }


### PR DESCRIPTION
This PR implements Task 3 from `docs/TIMESERIES.md`, adding sliding window support to the `WindowByTime` operator.

Key changes:
- `WindowByTime` now correctly handles the `slide` parameter when it's different from `duration`.
- Uses a `SortedDictionary` to track active windows, ensuring monotonic cleanup and efficient item distribution.
- Windows are aligned to the epoch using `UtcTicks` for deterministic behavior.
- Added comprehensive tests in `TimeseriesTests.cs` covering overlapping windows, sparse sliding (with gaps), and exact boundary inclusion.
- Documentation updated to mark the task as complete.

Note: Because sliding windows can overlap, sequential consumption of the outer stream can lead to deadlocks if the outer buffer is full. The implementation honors backpressure as requested, and tests have been updated to use concurrent consumption (e.g., `FlatMap` style or parallel tasks) to avoid such hangs.

---
*PR created automatically by Jules for task [3318863362745306506](https://jules.google.com/task/3318863362745306506) started by @khurram-uworx*