### PR TITLE
Harden Core Supervision Primitive (Task #2)

### DIFF
--- a/docs/UNION.md
+++ b/docs/UNION.md
@@ -142,7 +142,7 @@ Document one canonical semantic contract for supervision, cancellation, completi
 - `docs/UNION.md`
 - `WORK.md` (optional decision log entry)
 
-## Task 2: Harden Core Supervision Primitive
+## ✅ Task 2: Harden Core Supervision Primitive
 
 ### Priority
 

--- a/src/Streamix.Tests/StreamScopeTests.cs
+++ b/src/Streamix.Tests/StreamScopeTests.cs
@@ -1,0 +1,148 @@
+using NUnit.Framework;
+using Streamix.Implementations;
+
+namespace Streamix.Tests;
+
+[TestFixture]
+public class StreamScopeTests
+{
+    [Test]
+    public async Task ScopedAsync_WaitsForAllChildren()
+    {
+        var task1Finished = false;
+        var task2Finished = false;
+
+        await Stream.ScopedAsync(async scope =>
+        {
+            scope.Run(async ct =>
+            {
+                await Task.Delay(50, ct);
+                task1Finished = true;
+            });
+            scope.Run(async ct =>
+            {
+                await Task.Delay(100, ct);
+                task2Finished = true;
+            });
+        });
+
+        Assert.That(task1Finished, Is.True);
+        Assert.That(task2Finished, Is.True);
+    }
+
+    [Test]
+    public async Task ScopedAsync_ChildFailureCancelsSiblings()
+    {
+        var siblingCancelled = false;
+        var tcs = new TaskCompletionSource();
+
+        var exception = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await Stream.ScopedAsync(async scope =>
+            {
+                scope.Run(async ct =>
+                {
+                    await tcs.Task;
+                    throw new InvalidOperationException("Boom");
+                });
+
+                scope.Run(async ct =>
+                {
+                    try
+                    {
+                        await Task.Delay(Timeout.Infinite, ct);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        siblingCancelled = true;
+                    }
+                });
+
+                await Task.Delay(10); // Give tasks time to start
+                tcs.SetResult();
+            });
+        });
+
+        Assert.That(exception?.Message, Is.EqualTo("Boom"));
+        Assert.That(siblingCancelled, Is.True);
+    }
+
+    [Test]
+    public async Task ScopedAsync_ParentCancellationCancelsChildren()
+    {
+        var childCancelled = false;
+        using var cts = new CancellationTokenSource();
+
+        var task = Stream.ScopedAsync(async scope =>
+        {
+            scope.Run(async ct =>
+            {
+                try
+                {
+                    await Task.Delay(Timeout.Infinite, ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    childCancelled = true;
+                }
+            });
+
+            await Task.Delay(Timeout.Infinite, scope.CancellationToken);
+        }, cts.Token);
+
+        await Task.Delay(50);
+        await cts.CancelAsync();
+
+        Assert.CatchAsync<OperationCanceledException>(async () => await task);
+        Assert.That(childCancelled, Is.True);
+    }
+
+    [Test]
+    public async Task ScopedAsync_PropagatesFirstException()
+    {
+        var exception = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await Stream.ScopedAsync(async scope =>
+            {
+                scope.Run(async ct =>
+                {
+                    await Task.Delay(10, ct);
+                    throw new InvalidOperationException("First");
+                });
+
+                scope.Run(async ct =>
+                {
+                    await Task.Delay(50, ct);
+                    throw new ArgumentException("Second");
+                });
+            });
+        });
+
+        Assert.That(exception?.Message, Is.EqualTo("First"));
+    }
+
+    [Test]
+    public async Task ScopedAsync_WaitsForChildrenEvenOnFailure()
+    {
+        var childFinishedAfterFailure = false;
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await Stream.ScopedAsync(async scope =>
+            {
+                scope.Run(async ct =>
+                {
+                    throw new InvalidOperationException("Boom");
+                });
+
+                scope.Run(async ct =>
+                {
+                    await Task.Delay(100, ct).ContinueWith(_ => { });
+                    childFinishedAfterFailure = true;
+                });
+            });
+        });
+
+        Assert.That(childFinishedAfterFailure, Is.True);
+    }
+}

--- a/src/Streamix/Implementations/StreamScope.cs
+++ b/src/Streamix/Implementations/StreamScope.cs
@@ -7,6 +7,8 @@ internal sealed class StreamScope : IStreamScope, IAsyncDisposable
     readonly CancellationTokenSource cts;
     readonly ConcurrentBag<Task> tasks = new();
     readonly object syncRoot = new();
+    readonly object errorSyncRoot = new();
+    Exception? firstException;
     bool disposed;
 
     public StreamScope(CancellationToken externalToken)
@@ -15,6 +17,25 @@ internal sealed class StreamScope : IStreamScope, IAsyncDisposable
     }
 
     public CancellationToken CancellationToken => cts.Token;
+
+    internal void RecordException(Exception ex)
+    {
+        if (ex is OperationCanceledException && cts.IsCancellationRequested)
+        {
+            return;
+        }
+
+        lock (errorSyncRoot)
+        {
+            firstException ??= ex;
+        }
+
+        try
+        {
+            cts.Cancel();
+        }
+        catch (ObjectDisposedException) { }
+    }
 
     public void Run(Func<CancellationToken, Task> work)
     {
@@ -31,13 +52,9 @@ internal sealed class StreamScope : IStreamScope, IAsyncDisposable
                 {
                     await work(cts.Token);
                 }
-                catch (OperationCanceledException) when (cts.IsCancellationRequested)
+                catch (Exception ex)
                 {
-                    // Expected
-                }
-                catch (Exception)
-                {
-                    await cts.CancelAsync();
+                    RecordException(ex);
                     throw;
                 }
             }, cts.Token);
@@ -48,63 +65,43 @@ internal sealed class StreamScope : IStreamScope, IAsyncDisposable
 
     public async Task WaitAllAsync()
     {
+        // Continuously wait for all registered tasks to complete.
+        // We use a loop because new tasks might be registered while we are waiting for current ones.
         while (true)
         {
             Task[] toWait;
             lock (syncRoot)
             {
+                // Snapshot the current set of incomplete tasks.
                 toWait = tasks.Where(t => !t.IsCompleted).ToArray();
             }
 
+            // If no incomplete tasks remain, all children have reached a terminal state.
             if (toWait.Length == 0) break;
 
             try
             {
+                // Wait for the current batch of tasks to settle.
+                // We use WhenAll but catch exceptions because we want all tasks to settle
+                // before we propagate the first failure recorded via RecordException.
                 await Task.WhenAll(toWait);
             }
             catch
             {
-                // We don't catch here to propagate first failure,
-                // but we need to make sure we wait for all before finishing ScopedAsync.
-                // Actually, Task.WhenAll will throw if any fails.
-                // But we want to ensure other tasks are cancelled and waited upon.
-                break;
+                // Exceptions are captured by individual tasks and reported via RecordException,
+                // so we ignore them here to continue waiting for other siblings to settle.
             }
         }
 
-        // Final wait for everything to settle (including cancellations)
-        List<Task> allTasks;
-        lock (syncRoot)
+        // After all tasks have settled, propagate the first failure if one occurred.
+        if (firstException != null)
         {
-            allTasks = tasks.ToList();
+            throw firstException;
         }
 
-        if (allTasks.Count > 0)
+        if (cts.IsCancellationRequested)
         {
-            try
-            {
-                await Task.WhenAll(allTasks);
-            }
-            catch (OperationCanceledException) when (cts.IsCancellationRequested)
-            {
-                // If there's any non-cancellation exception, throw that instead
-                var firstFaulted = allTasks.FirstOrDefault(t => t.IsFaulted);
-                if (firstFaulted?.Exception != null)
-                {
-                    throw firstFaulted.Exception.InnerException ?? firstFaulted.Exception;
-                }
-                throw;
-            }
-            catch
-            {
-                // Propagate exception after all have settled
-                var firstFaulted = allTasks.FirstOrDefault(t => t.IsFaulted);
-                if (firstFaulted?.Exception != null)
-                {
-                    throw firstFaulted.Exception.InnerException ?? firstFaulted.Exception;
-                }
-                throw;
-            }
+            throw new OperationCanceledException(cts.Token);
         }
     }
 

--- a/src/Streamix/Stream.cs
+++ b/src/Streamix/Stream.cs
@@ -616,19 +616,23 @@ public static class Stream
     {
         ArgumentNullException.ThrowIfNull(action);
 
-        await using var scope = new StreamScope(cancellationToken);
+        var scope = new StreamScope(cancellationToken);
         try
         {
-            await action(scope);
-        }
-        catch (Exception)
-        {
-            // If the main action fails, we want to cancel siblings
-            await scope.DisposeAsync();
-            await scope.WaitAllAsync();
-            throw;
-        }
+            try
+            {
+                await action(scope);
+            }
+            catch (Exception ex)
+            {
+                scope.RecordException(ex);
+            }
 
-        await scope.WaitAllAsync();
+            await scope.WaitAllAsync();
+        }
+        finally
+        {
+            await scope.DisposeAsync();
+        }
     }
 }


### PR DESCRIPTION
I have hardened the core supervision primitive `StreamScope` and integrated it with `Stream.ScopedAsync` to satisfy the structured concurrency requirements defined in the Final Union Contract.

Key improvements:
- **First Exception Propagation**: `StreamScope` now captures and propagates the first encountered non-cancellation exception after all child tasks have settled.
- **Deterministic Completion**: `WaitAllAsync` now ensures all registered children reach a terminal state (success, fault, or cancellation) before returning.
- **Fail-Fast Semantics**: A failure in any child task (or the parent block) now triggers immediate cancellation of all siblings within the scope.
- **Resource Safety**: Fixed an `ObjectDisposedException` in `ScopedAsync` by ensuring `WaitAllAsync` completes before the scope is disposed.
- **Verification**: Added `src/Streamix.Tests/StreamScopeTests.cs` with coverage for success, cancellation, and failure scenarios.

I also updated `docs/UNION.md` to reflect the completion of this task.

---
*PR created automatically by Jules for task [4843676484206342140](https://jules.google.com/task/4843676484206342140) started by @khurram-uworx*