### PR TITLE
Implement watermark-aware event-time windowing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,6 +82,7 @@ Streamix is designed for high-performance asynchronous streaming with the follow
 - Zero-Allocation Sequential Operators: Basic operators like `Map`, `Filter`, `Take`, and `Skip` are implemented as thin wrappers over `IAsyncEnumerable<T>` using async iterators. They introduce minimal overhead and do not involve intermediate buffering.
 - Bounded Concurrency: All flattening and parallel operators accept a `maxConcurrency` parameter, allowing you to strictly control the number of simultaneous asynchronous operations.
 - Materialization Awareness: Operators that require state across multiple items, such as `Buffer(count)`, `Window(count)`, or `Replay(bufferSize)`, involve allocations proportional to their requested size. These should be used with appropriate bounds to manage memory usage.
+- Watermark-Aware Windowing: Supports bounded out-of-order data processing by deriving a monotonic watermark (`maxObservedEventTimestamp - outOfOrderness`). Late events (timestamp <= watermark) are dropped, and windows are finalized once the watermark reaches the window's end.
 - Hot Stream Efficiency: `ConnectableStream<T>` (via `Publish()` or `Replay()`) manages a single underlying subscription for multiple downstream consumers, reducing redundant upstream work and resource consumption.
 
 ## Boundary Semantics

--- a/README.md
+++ b/README.md
@@ -68,7 +68,10 @@ Streamix supports event-time windowing with tumbling and sliding windows.
 ```csharp
 await sensorStream
     .MapWithTimestamp(s => s.ObservedAt)
-    .WindowByTime(duration: TimeSpan.FromMinutes(5), slide: TimeSpan.FromMinutes(1))
+    .WindowByTime(
+        duration: TimeSpan.FromMinutes(5),
+        slide: TimeSpan.FromMinutes(1),
+        outOfOrderness: TimeSpan.FromSeconds(30))
     .FlatMap(window => window.MaxAsync(s => s.Value))
     .ForEachAsync(Console.WriteLine);
 ```

--- a/docs/TIMESERIES.md
+++ b/docs/TIMESERIES.md
@@ -93,7 +93,7 @@ The remaining work is future enhancement planning in four areas:
 - Task 5 can run in parallel with later planning work once the team decides which operator is worth adding next.
 - Shared files likely to create merge conflicts are `README.md`, `ARCHITECTURE.md`, and time-series-related test files.
 
-## Task 1: Define Watermark And Late-Event Semantics
+## ✅ Task 1: Define Watermark And Late-Event Semantics
 
 ### Priority
 
@@ -139,6 +139,101 @@ Decide the product semantics for:
 - one explicit watermark/late-event semantic model is documented
 - the design states what happens to late events and when windows are considered complete
 - the design is narrow enough to implement and test without guesswork
+
+### 🎯 Task 1 decision
+
+Task 1 is now settled with a narrow bounded-out-of-orderness model for future watermark-aware event-time operators.
+
+The intent is to make Task 2 implementation work mechanical rather than interpretive.
+
+### Canonical semantic model
+
+- The existing `WindowByTime` contract remains unchanged and remains suitable for already ordered event-time input.
+- Watermark-aware behavior must be introduced as an explicit new operator or explicit opt-in mode. It must not silently change the behavior of the current `WindowByTime`.
+- A watermark is an event-time cutoff, not wall-clock time.
+- The watermark is monotonic and never moves backwards.
+- For the initial design, the watermark is derived from observed events rather than injected as a separate control stream.
+- The derived watermark is:
+  `watermark = maxObservedEventTimestamp - outOfOrderness`
+- `outOfOrderness` is a non-negative duration that defines how much reordering the operator tolerates before an event is considered late.
+- If `outOfOrderness = TimeSpan.Zero`, the operator expects strictly non-decreasing event timestamps.
+- Watermark progression happens only when a new event is observed or when upstream completes. The initial design does not include idle-source heuristics or processing-time timers.
+
+### Event classification
+
+- An event is on time if `event.Timestamp > currentWatermark` at the moment the operator receives it.
+- An event is late if `event.Timestamp <= currentWatermark` at the moment the operator receives it.
+- Equality is intentionally late:
+  if the watermark has reached `2025-01-01T00:05:00Z`, an event with timestamp `2025-01-01T00:05:00Z` is late.
+- Late-ness is determined on arrival. Once an event has been admitted to a window, later watermark advancement does not retroactively invalidate it.
+
+### Window membership and completion
+
+- Window membership remains based on event time and existing boundary rules.
+- Tumbling and sliding windows continue to use half-open intervals:
+  `[windowStart, windowEnd)`
+- An admitted event may belong only to windows whose event-time interval contains its timestamp.
+- A window becomes complete when `watermark >= windowEnd`.
+- Once complete, a window is final:
+  it emits no more items, is not reopened, and is not revised.
+- On upstream completion, all remaining open windows are completed immediately, equivalent to advancing the watermark to positive infinity for finalization purposes.
+
+### Late-event policy for the initial contract
+
+- The initial watermark-aware contract does not support allowed lateness.
+- The initial watermark-aware contract does not support retractions, corrections, or re-opening closed windows.
+- A late event is dropped from the main windowed output.
+- A late event must not be inserted into any already completed window.
+- A late event must not create a new window by itself.
+- The initial contract does not require a side output for late events.
+- If the library later adds explicit late-event routing, that must be a separate additive API and must not change the drop behavior of the initial contract unless the caller opts in explicitly.
+
+### Relationship to current implementation
+
+- The current `WindowByTime` implementation closes windows based on observed event timestamps and source completion, not on a formal watermark.
+- The current implementation assumes the input stream is already ordered enough for its boundary logic to be meaningful.
+- Task 2 must preserve the current implementation for callers who do not opt into watermark-aware behavior.
+- Watermark-aware behavior is therefore an additive event-time mode, not a reinterpretation of existing tests.
+
+### Required downstream visibility rules
+
+- Downstream consumers observe each window exactly once.
+- Downstream consumers observe only final window contents.
+- Downstream consumers do not observe partial completion signals followed by later corrections.
+- Downstream consumers do not observe dropped late events in the main output.
+- If diagnostics are added later, they are informational and separate from the main data path.
+
+### Explicit non-goals for the first implementation
+
+- no configurable allowed-lateness period after watermark completion
+- no separate watermark records in the public data stream
+- no processing-time fallback for idle partitions or idle sources
+- no retraction/update model for already emitted windows
+- no automatic side channel for late events
+- no implicit behavior change to `MapWithTimestamp` or `WindowByTime`
+
+### Mechanical rules for Task 2
+
+Coding agents implementing Task 2 should be able to apply the following rules directly:
+
+1. Track `maxObservedEventTimestamp`.
+2. Derive `currentWatermark = maxObservedEventTimestamp - outOfOrderness`.
+3. Before admitting an event, classify it as late when `event.Timestamp <= currentWatermark`.
+4. Drop late events from the main output.
+5. Admit on-time events to all matching windows under the existing half-open interval rules.
+6. After watermark advancement, complete every open window where `windowEnd <= currentWatermark`.
+7. Never reopen or mutate a completed window.
+8. When upstream completes, complete every remaining open window.
+
+### Test matrix implied by this contract
+
+- in-order input with `outOfOrderness = 0`
+- bounded out-of-order input that still arrives before the watermark cutoff
+- event exactly at the watermark boundary and therefore late
+- event earlier than the watermark and therefore dropped
+- windows that remain open until watermark advancement
+- final upstream completion that flushes remaining windows
+- cancellation and backpressure behavior unchanged relative to the existing operator model
 
 ### Files likely involved
 

--- a/docs/TIMESERIES.md
+++ b/docs/TIMESERIES.md
@@ -241,7 +241,7 @@ Coding agents implementing Task 2 should be able to apply the following rules di
 - `ARCHITECTURE.md`
 - `README.md`
 
-## Task 2: Implement Watermark-Aware Event-Time Behavior
+## ✅ Task 2: Implement Watermark-Aware Event-Time Behavior
 
 ### Priority
 

--- a/docs/TIMESERIES.md
+++ b/docs/TIMESERIES.md
@@ -93,7 +93,7 @@ The remaining work is future enhancement planning in four areas:
 - Task 5 can run in parallel with later planning work once the team decides which operator is worth adding next.
 - Shared files likely to create merge conflicts are `README.md`, `ARCHITECTURE.md`, and time-series-related test files.
 
-## Task 1: Define Watermark And Late-Event Semantics
+## ✅ Task 1: Define Watermark And Late-Event Semantics
 
 ### Priority
 
@@ -140,13 +140,108 @@ Decide the product semantics for:
 - the design states what happens to late events and when windows are considered complete
 - the design is narrow enough to implement and test without guesswork
 
+### 🎯 Task 1 decision
+
+Task 1 is now settled with a narrow bounded-out-of-orderness model for future watermark-aware event-time operators.
+
+The intent is to make Task 2 implementation work mechanical rather than interpretive.
+
+### Canonical semantic model
+
+- The existing `WindowByTime` contract remains unchanged and remains suitable for already ordered event-time input.
+- Watermark-aware behavior must be introduced as an explicit new operator or explicit opt-in mode. It must not silently change the behavior of the current `WindowByTime`.
+- A watermark is an event-time cutoff, not wall-clock time.
+- The watermark is monotonic and never moves backwards.
+- For the initial design, the watermark is derived from observed events rather than injected as a separate control stream.
+- The derived watermark is:
+  `watermark = maxObservedEventTimestamp - outOfOrderness`
+- `outOfOrderness` is a non-negative duration that defines how much reordering the operator tolerates before an event is considered late.
+- If `outOfOrderness = TimeSpan.Zero`, the operator expects strictly non-decreasing event timestamps.
+- Watermark progression happens only when a new event is observed or when upstream completes. The initial design does not include idle-source heuristics or processing-time timers.
+
+### Event classification
+
+- An event is on time if `event.Timestamp > currentWatermark` at the moment the operator receives it.
+- An event is late if `event.Timestamp <= currentWatermark` at the moment the operator receives it.
+- Equality is intentionally late:
+  if the watermark has reached `2025-01-01T00:05:00Z`, an event with timestamp `2025-01-01T00:05:00Z` is late.
+- Late-ness is determined on arrival. Once an event has been admitted to a window, later watermark advancement does not retroactively invalidate it.
+
+### Window membership and completion
+
+- Window membership remains based on event time and existing boundary rules.
+- Tumbling and sliding windows continue to use half-open intervals:
+  `[windowStart, windowEnd)`
+- An admitted event may belong only to windows whose event-time interval contains its timestamp.
+- A window becomes complete when `watermark >= windowEnd`.
+- Once complete, a window is final:
+  it emits no more items, is not reopened, and is not revised.
+- On upstream completion, all remaining open windows are completed immediately, equivalent to advancing the watermark to positive infinity for finalization purposes.
+
+### Late-event policy for the initial contract
+
+- The initial watermark-aware contract does not support allowed lateness.
+- The initial watermark-aware contract does not support retractions, corrections, or re-opening closed windows.
+- A late event is dropped from the main windowed output.
+- A late event must not be inserted into any already completed window.
+- A late event must not create a new window by itself.
+- The initial contract does not require a side output for late events.
+- If the library later adds explicit late-event routing, that must be a separate additive API and must not change the drop behavior of the initial contract unless the caller opts in explicitly.
+
+### Relationship to current implementation
+
+- The current `WindowByTime` implementation closes windows based on observed event timestamps and source completion, not on a formal watermark.
+- The current implementation assumes the input stream is already ordered enough for its boundary logic to be meaningful.
+- Task 2 must preserve the current implementation for callers who do not opt into watermark-aware behavior.
+- Watermark-aware behavior is therefore an additive event-time mode, not a reinterpretation of existing tests.
+
+### Required downstream visibility rules
+
+- Downstream consumers observe each window exactly once.
+- Downstream consumers observe only final window contents.
+- Downstream consumers do not observe partial completion signals followed by later corrections.
+- Downstream consumers do not observe dropped late events in the main output.
+- If diagnostics are added later, they are informational and separate from the main data path.
+
+### Explicit non-goals for the first implementation
+
+- no configurable allowed-lateness period after watermark completion
+- no separate watermark records in the public data stream
+- no processing-time fallback for idle partitions or idle sources
+- no retraction/update model for already emitted windows
+- no automatic side channel for late events
+- no implicit behavior change to `MapWithTimestamp` or `WindowByTime`
+
+### Mechanical rules for Task 2
+
+Coding agents implementing Task 2 should be able to apply the following rules directly:
+
+1. Track `maxObservedEventTimestamp`.
+2. Derive `currentWatermark = maxObservedEventTimestamp - outOfOrderness`.
+3. Before admitting an event, classify it as late when `event.Timestamp <= currentWatermark`.
+4. Drop late events from the main output.
+5. Admit on-time events to all matching windows under the existing half-open interval rules.
+6. After watermark advancement, complete every open window where `windowEnd <= currentWatermark`.
+7. Never reopen or mutate a completed window.
+8. When upstream completes, complete every remaining open window.
+
+### Test matrix implied by this contract
+
+- in-order input with `outOfOrderness = 0`
+- bounded out-of-order input that still arrives before the watermark cutoff
+- event exactly at the watermark boundary and therefore late
+- event earlier than the watermark and therefore dropped
+- windows that remain open until watermark advancement
+- final upstream completion that flushes remaining windows
+- cancellation and backpressure behavior unchanged relative to the existing operator model
+
 ### Files likely involved
 
 - `docs/TIMESERIES.md`
 - `ARCHITECTURE.md`
 - `README.md`
 
-## Task 2: Implement Watermark-Aware Event-Time Behavior
+## ✅ Task 2: Implement Watermark-Aware Event-Time Behavior
 
 ### Priority
 

--- a/src/Streamix.Tests/Extensions/WatermarkTests.cs
+++ b/src/Streamix.Tests/Extensions/WatermarkTests.cs
@@ -1,0 +1,153 @@
+using NUnit.Framework;
+using Streamix;
+
+namespace Streamix.Tests.Extensions;
+
+[TestFixture]
+public class WatermarkTests
+{
+    [Test]
+    public async Task WindowByTime_WithWatermark_InOrder_ShouldWork()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(10);
+        var outOfOrderness = TimeSpan.Zero;
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start.AddMinutes(1)),
+            Timestamped.Create(2, start.AddMinutes(5)),
+            Timestamped.Create(3, start.AddMinutes(11)), // This should close the first window [0, 10)
+        };
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration, outOfOrderness: outOfOrderness);
+
+        var windowStreams = await windows.ToListAsync();
+        Assert.That(windowStreams, Has.Count.EqualTo(2));
+
+        var w1 = await windowStreams[0].ToListAsync();
+        var w2 = await windowStreams[1].ToListAsync();
+
+        Assert.That(w1.Select(x => x.Value), Is.EquivalentTo(new[] { 1, 2 }));
+        Assert.That(w2.Select(x => x.Value), Is.EquivalentTo(new[] { 3 }));
+    }
+
+    [Test]
+    public async Task WindowByTime_WithWatermark_OutOfOrder_WithinBound_ShouldBeAdmitted()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(10);
+        var outOfOrderness = TimeSpan.FromMinutes(5);
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start.AddMinutes(5)),  // Watermark = 5 - 5 = 0
+            Timestamped.Create(2, start.AddMinutes(2)),  // 2 > 0, admitted to [0, 10)
+            Timestamped.Create(3, start.AddMinutes(12)), // Watermark = 12 - 5 = 7. [0, 10) is still open because 10 > 7
+            Timestamped.Create(4, start.AddMinutes(8)),  // 8 > 7, admitted to [0, 10)
+            Timestamped.Create(5, start.AddMinutes(16)), // Watermark = 16 - 5 = 11. [0, 10) closed because 10 <= 11
+        };
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration, outOfOrderness: outOfOrderness);
+
+        var windowStreams = await windows.ToListAsync();
+        Assert.That(windowStreams, Has.Count.EqualTo(2));
+
+        var w1 = await windowStreams[0].ToListAsync();
+        Assert.That(w1.Select(x => x.Value), Is.EquivalentTo(new[] { 1, 2, 4 }));
+
+        var w2 = await windowStreams[1].ToListAsync();
+        Assert.That(w2.Select(x => x.Value), Is.EquivalentTo(new[] { 3, 5 }));
+    }
+
+    [Test]
+    public async Task WindowByTime_WithWatermark_LateData_ShouldBeDropped()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(10);
+        var outOfOrderness = TimeSpan.FromMinutes(2);
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start.AddMinutes(5)),  // Watermark = 5 - 2 = 3
+            Timestamped.Create(2, start.AddMinutes(2)),  // 2 <= 3, LATE, dropped
+            Timestamped.Create(3, start.AddMinutes(10)), // Watermark = 10 - 2 = 8
+            Timestamped.Create(4, start.AddMinutes(7)),  // 7 <= 8, LATE, dropped
+            Timestamped.Create(5, start.AddMinutes(15)), // Watermark = 15 - 2 = 13. [0, 10) closed.
+        };
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration, outOfOrderness: outOfOrderness);
+
+        var windowStreams = await windows.ToListAsync();
+        var windowList = new List<List<Timestamped<int>>>();
+        foreach(var w in windowStreams) windowList.Add(await w.ToListAsync());
+
+        Assert.That(windowList, Has.Count.EqualTo(2));
+        Assert.That(windowList[0].Select(x => x.Value), Is.EquivalentTo(new[] { 1 }));
+        Assert.That(windowList[1].Select(x => x.Value), Is.EquivalentTo(new[] { 3, 5 }));
+    }
+
+    [Test]
+    public async Task WindowByTime_WithWatermark_UpstreamCompletion_ShouldFlush()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(10);
+        var outOfOrderness = TimeSpan.FromMinutes(5);
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start.AddMinutes(1)), // Watermark = 1 - 5 = -4
+        };
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration, outOfOrderness: outOfOrderness);
+
+        var windowStreams = await windows.ToListAsync();
+        Assert.That(windowStreams, Has.Count.EqualTo(1));
+        var w1 = await windowStreams[0].ToListAsync();
+        Assert.That(w1.Select(x => x.Value), Is.EquivalentTo(new[] { 1 }));
+    }
+
+    [Test]
+    public async Task WindowByTime_WithWatermark_Sliding_ShouldWork()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(10);
+        var slide = TimeSpan.FromMinutes(5);
+        var outOfOrderness = TimeSpan.FromMinutes(2);
+
+        // Windows:
+        // W-5: [-5, 5)
+        // W0: [0, 10)
+        // W5: [5, 15)
+        // W10: [10, 20)
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start.AddMinutes(1)),  // Max=1, WM=-1. W-5, W0 created. 1 added to W-5, W0.
+            Timestamped.Create(2, start.AddMinutes(6)),  // Max=6, WM=4. W5 created. 2 added to W0, W5.
+            Timestamped.Create(3, start.AddMinutes(4)),  // 4 <= 4, LATE, dropped.
+            Timestamped.Create(4, start.AddMinutes(13)), // Max=13, WM=11. W10 created. W-5, W0 close. 4 added to W5, W10.
+            Timestamped.Create(5, start.AddMinutes(8)),  // 8 <= 11, LATE, dropped.
+        };
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration, slide, outOfOrderness: outOfOrderness);
+
+        var windowStreams = await windows.ToListAsync();
+        Assert.That(windowStreams, Has.Count.EqualTo(4));
+
+        var wm5 = await windowStreams[0].ToListAsync();
+        var w0 = await windowStreams[1].ToListAsync();
+        var w5 = await windowStreams[2].ToListAsync();
+        var w10 = await windowStreams[3].ToListAsync();
+
+        Assert.That(wm5.Select(x => x.Value), Is.EquivalentTo(new[] { 1 }));
+        Assert.That(w0.Select(x => x.Value), Is.EquivalentTo(new[] { 1, 2 }));
+        Assert.That(w5.Select(x => x.Value), Is.EquivalentTo(new[] { 2, 4 }));
+        Assert.That(w10.Select(x => x.Value), Is.EquivalentTo(new[] { 4 }));
+    }
+}

--- a/src/Streamix/Extensions/TimeseriesExtensions.cs
+++ b/src/Streamix/Extensions/TimeseriesExtensions.cs
@@ -29,16 +29,19 @@ public static class TimeseriesExtensions
     /// <param name="slide">The interval at which windows are started. If null, tumbling windows are used (slide = duration).</param>
     /// <param name="capacity">The capacity of the buffer for each window.</param>
     /// <param name="mode">The backpressure mode for each window.</param>
+    /// <param name="outOfOrderness">The maximum out-of-orderness allowed before an event is considered late. If not null, enables watermark-aware behavior.</param>
     /// <returns>A stream of window streams.</returns>
     public static IStream<IStream<Timestamped<T>>> WindowByTime<T>(
         this IStream<Timestamped<T>> source,
         TimeSpan duration,
         TimeSpan? slide = null,
         int capacity = 16,
-        ChannelBackpressureMode mode = ChannelBackpressureMode.Wait)
+        ChannelBackpressureMode mode = ChannelBackpressureMode.Wait,
+        TimeSpan? outOfOrderness = null)
     {
         if (duration <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(duration));
         if (slide.HasValue && slide.Value <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(slide));
+        if (outOfOrderness.HasValue && outOfOrderness.Value < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(outOfOrderness));
 
         return Stream.Create<IStream<Timestamped<T>>>(async emitter =>
         {
@@ -47,41 +50,98 @@ public static class TimeseriesExtensions
             if (slide == null || slide == duration)
             {
                 // Tumbling window logic
-                Channel<Timestamped<T>>? currentWindowChannel = null;
-                DateTimeOffset? currentWindowEnd = null;
-
-                try
+                if (outOfOrderness.HasValue)
                 {
-                    await foreach (var item in source.WithCancellation(ct))
+                    var activeWindows = new SortedDictionary<long, Channel<Timestamped<T>>>();
+                    long? maxObservedTicks = null;
+
+                    try
                     {
-                        if (currentWindowChannel == null || item.Timestamp >= currentWindowEnd)
+                        await foreach (var item in source.WithCancellation(ct))
                         {
-                            currentWindowChannel?.Writer.TryComplete();
+                            var currentWatermark = maxObservedTicks.HasValue ? maxObservedTicks.Value - outOfOrderness.Value.Ticks : long.MinValue;
+
+                            if (item.Timestamp.UtcTicks <= currentWatermark)
+                                continue;
+
+                            if (!maxObservedTicks.HasValue || item.Timestamp.UtcTicks > maxObservedTicks.Value)
+                                maxObservedTicks = item.Timestamp.UtcTicks;
+
+                            var newWatermark = maxObservedTicks.Value - outOfOrderness.Value.Ticks;
+
+                            // Clean up
+                            while (activeWindows.Count > 0)
+                            {
+                                var first = activeWindows.First();
+                                if (first.Key + duration.Ticks <= newWatermark)
+                                {
+                                    first.Value.Writer.TryComplete();
+                                    activeWindows.Remove(first.Key);
+                                }
+                                else break;
+                            }
 
                             var startTicks = (item.Timestamp.UtcTicks / duration.Ticks) * duration.Ticks;
-                            var start = new DateTimeOffset(startTicks, TimeSpan.Zero);
-                            currentWindowEnd = start + duration;
+                            if (!activeWindows.TryGetValue(startTicks, out var channel))
+                            {
+                                channel = ChannelExecution.CreateChannel<Timestamped<T>>(capacity, mode, singleWriter: true);
+                                activeWindows[startTicks] = channel;
+                                await emitter.EmitAsync(Stream.From(innerCt => channel.Reader.ReadAllAsync(innerCt)));
+                            }
 
-                            var channel = ChannelExecution.CreateChannel<Timestamped<T>>(capacity, mode, singleWriter: true);
-                            currentWindowChannel = channel;
-
-                            await emitter.EmitAsync(Stream.From(innerCt => channel.Reader.ReadAllAsync(innerCt)));
+                            await ChannelExecution.WriteAsync(channel.Writer, item, mode, ct);
                         }
-
-                        await ChannelExecution.WriteAsync(currentWindowChannel.Writer, item, mode, ct);
+                    }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+                    catch (Exception ex)
+                    {
+                        foreach (var window in activeWindows.Values) window.Writer.TryComplete(ex);
+                        throw;
+                    }
+                    finally
+                    {
+                        foreach (var window in activeWindows.Values) window.Writer.TryComplete();
+                        activeWindows.Clear();
                     }
                 }
-                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                else
                 {
-                }
-                catch (Exception ex)
-                {
-                    currentWindowChannel?.Writer.TryComplete(ex);
-                    throw;
-                }
-                finally
-                {
-                    currentWindowChannel?.Writer.TryComplete();
+                    Channel<Timestamped<T>>? currentWindowChannel = null;
+                    DateTimeOffset? currentWindowEnd = null;
+
+                    try
+                    {
+                        await foreach (var item in source.WithCancellation(ct))
+                        {
+                            if (currentWindowChannel == null || item.Timestamp >= currentWindowEnd)
+                            {
+                                currentWindowChannel?.Writer.TryComplete();
+
+                                var startTicks = (item.Timestamp.UtcTicks / duration.Ticks) * duration.Ticks;
+                                var start = new DateTimeOffset(startTicks, TimeSpan.Zero);
+                                currentWindowEnd = start + duration;
+
+                                var channel = ChannelExecution.CreateChannel<Timestamped<T>>(capacity, mode, singleWriter: true);
+                                currentWindowChannel = channel;
+
+                                await emitter.EmitAsync(Stream.From(innerCt => channel.Reader.ReadAllAsync(innerCt)));
+                            }
+
+                            await ChannelExecution.WriteAsync(currentWindowChannel.Writer, item, mode, ct);
+                        }
+                    }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                    {
+                    }
+                    catch (Exception ex)
+                    {
+                        currentWindowChannel?.Writer.TryComplete(ex);
+                        throw;
+                    }
+                    finally
+                    {
+                        currentWindowChannel?.Writer.TryComplete();
+                    }
                 }
             }
             else
@@ -89,24 +149,36 @@ public static class TimeseriesExtensions
                 // Sliding window logic
                 var activeWindows = new SortedDictionary<long, Channel<Timestamped<T>>>();
                 long? firstStartTicks = null;
+                long? maxObservedTicks = null;
 
                 try
                 {
                     await foreach (var item in source.WithCancellation(ct))
                     {
+                        var currentWatermark = outOfOrderness.HasValue
+                            ? (maxObservedTicks.HasValue ? maxObservedTicks.Value - outOfOrderness.Value.Ticks : long.MinValue)
+                            : long.MinValue;
+
+                        if (outOfOrderness.HasValue && item.Timestamp.UtcTicks <= currentWatermark)
+                            continue;
+
+                        if (!maxObservedTicks.HasValue || item.Timestamp.UtcTicks > maxObservedTicks.Value)
+                            maxObservedTicks = item.Timestamp.UtcTicks;
+
+                        var effectiveWatermark = outOfOrderness.HasValue
+                            ? maxObservedTicks.Value - outOfOrderness.Value.Ticks
+                            : item.Timestamp.UtcTicks;
+
                         // Clean up expired windows
                         while (activeWindows.Count > 0)
                         {
                             var first = activeWindows.First();
-                            if (first.Key + duration.Ticks <= item.Timestamp.UtcTicks)
+                            if (first.Key + duration.Ticks <= effectiveWatermark)
                             {
                                 first.Value.Writer.TryComplete();
                                 activeWindows.Remove(first.Key);
                             }
-                            else
-                            {
-                                break;
-                            }
+                            else break;
                         }
 
                         var latestStartTicks = (item.Timestamp.UtcTicks / slide.Value.Ticks) * slide.Value.Ticks;
@@ -119,13 +191,17 @@ public static class TimeseriesExtensions
                                 firstStartTicks += slide.Value.Ticks;
                         }
 
-                        var effectiveMinStart = Math.Max(item.Timestamp.UtcTicks - duration.Ticks + 1, firstStartTicks.Value);
+                        var effectiveMinStart = outOfOrderness.HasValue
+                             ? (item.Timestamp.UtcTicks - duration.Ticks + 1)
+                             : Math.Max(item.Timestamp.UtcTicks - duration.Ticks + 1, firstStartTicks.Value);
 
                         // Identify windows to create (in chronological order)
-
                         var windowsToCreate = new List<long>();
                         for (var s = latestStartTicks; s >= effectiveMinStart; s -= slide.Value.Ticks)
                         {
+                            if (outOfOrderness.HasValue && s + duration.Ticks <= effectiveWatermark)
+                                break;
+
                             if (!activeWindows.ContainsKey(s)) windowsToCreate.Add(s);
                         }
                         windowsToCreate.Reverse();


### PR DESCRIPTION
This change implements Task 2 of the Time Series roadmap. It introduces watermark-aware event-time windowing to Streamix, allowing for controlled processing of out-of-order data.

Key changes:
- `WindowByTime` now accepts an optional `outOfOrderness` TimeSpan.
- When provided, it tracks the maximum observed event timestamp and derives a monotonic watermark.
- Events older than the watermark are dropped.
- Windows are finalized and closed as soon as the watermark reaches the window's end boundary.
- Full documentation updates in `ARCHITECTURE.md` and `README.md`.
- New test suite `WatermarkTests` verifies in-order, out-of-order, late-event, and sliding window scenarios.

This implementation preserves existing behavior for callers not opting into watermarks.

---
*PR created automatically by Jules for task [5309581727175427259](https://jules.google.com/task/5309581727175427259) started by @khurram-uworx*