### PR TITLE
Implement Watermark-Aware Event-Time Windowing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -67,6 +67,16 @@ Streamix uses a unified supervision model for both structured concurrency (`Stre
 - Caller-owned `DbContext` overloads are intentionally excluded so that subscription ownership, disposal, and same-context execution rules stay explicit and safe.
 - EF-specific batching or paging helpers are intentionally deferred until real usage shows a gap that the buffered-versus-streamed choice plus existing Streamix operators does not address well.
 
+## Time-Series and Watermarking
+
+Streamix supports event-time processing with watermark-aware windowing.
+
+- **Watermark Definition**: A watermark is a monotonic event-time cutoff derived from observed event timestamps: `watermark = maxObservedEventTimestamp - outOfOrderness`.
+- **Late Events**: An event is considered late if its timestamp is less than or equal to the current watermark. Late events are dropped from the main windowed output.
+- **Window Completion**: A window is considered complete and emitted when the watermark reaches or exceeds the window's end boundary.
+- **Tumbling and Sliding Windows**: Both window types support watermark-aware processing via the `outOfOrderness` parameter.
+- **Deterministic Finalization**: When the upstream source completes, all remaining open windows are finalized and emitted immediately, regardless of the current watermark.
+
 ## Implementation Notes
 
 - Channels for flow control

--- a/README.md
+++ b/README.md
@@ -63,12 +63,16 @@ var result = await (
 ).ToListAsync();
 ```
 
-Streamix supports event-time windowing with tumbling and sliding windows.
+Streamix supports event-time windowing with tumbling and sliding windows. It also supports watermark-aware processing for out-of-order data.
 
 ```csharp
 await sensorStream
     .MapWithTimestamp(s => s.ObservedAt)
-    .WindowByTime(duration: TimeSpan.FromMinutes(5), slide: TimeSpan.FromMinutes(1))
+    // Handle up to 30 seconds of out-of-orderness
+    .WindowByTime(
+        duration: TimeSpan.FromMinutes(5),
+        slide: TimeSpan.FromMinutes(1),
+        outOfOrderness: TimeSpan.FromSeconds(30))
     .FlatMap(window => window.MaxAsync(s => s.Value))
     .ForEachAsync(Console.WriteLine);
 ```

--- a/docs/TIMESERIES.md
+++ b/docs/TIMESERIES.md
@@ -241,7 +241,7 @@ Coding agents implementing Task 2 should be able to apply the following rules di
 - `ARCHITECTURE.md`
 - `README.md`
 
-## Task 2: Implement Watermark-Aware Event-Time Behavior
+## ✅ Task 2: Implement Watermark-Aware Event-Time Behavior
 
 ### Priority
 

--- a/src/Streamix.Tests/Extensions/WatermarkTests.cs
+++ b/src/Streamix.Tests/Extensions/WatermarkTests.cs
@@ -1,0 +1,175 @@
+using NUnit.Framework;
+using Streamix;
+
+namespace Streamix.Tests.Extensions;
+
+[TestFixture]
+public class WatermarkTests
+{
+    [Test]
+    public async Task WindowByTime_Watermark_Tumbling_ShouldDropLateEvents()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(10);
+        var outOfOrderness = TimeSpan.FromMinutes(5);
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start.AddMinutes(1)),  // Watermark: none -> -4
+            Timestamped.Create(2, start.AddMinutes(12)), // Watermark: 1 -> 7. Admitted to [10, 20)
+            Timestamped.Create(3, start.AddMinutes(6)),  // Watermark: 7. 6 <= 7, so LATE. Dropped.
+            Timestamped.Create(4, start.AddMinutes(15)), // Watermark: 7 -> 10. Admitted to [10, 20)
+            Timestamped.Create(5, start.AddMinutes(7)),  // Watermark: 10. 7 <= 10, so LATE. Dropped.
+            Timestamped.Create(6, start.AddMinutes(21)), // Watermark: 10 -> 16. [10, 20) completes. Admitted to [20, 30)
+        };
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration, outOfOrderness: outOfOrderness);
+
+        var windowList = new List<List<int>>();
+        await windows.FlatMap(async w =>
+        {
+            var list = await w.Map(x => x.Value).ToListAsync();
+            lock (windowList) windowList.Add(list);
+            return 0;
+        }).DrainAsync();
+
+        Assert.That(windowList, Has.Count.EqualTo(3));
+
+        // Windows:
+        // [0, 10): contains {1}
+        // [10, 20): contains {2, 4}
+        // [20, 30): contains {6}
+
+        Assert.That(windowList, Has.Some.EquivalentTo(new[] { 1 }));
+        Assert.That(windowList, Has.Some.EquivalentTo(new[] { 2, 4 }));
+        Assert.That(windowList, Has.Some.EquivalentTo(new[] { 6 }));
+    }
+
+    [Test]
+    public async Task WindowByTime_Watermark_Sliding_ShouldDropLateEvents()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(10);
+        var slide = TimeSpan.FromMinutes(5);
+        var outOfOrderness = TimeSpan.FromMinutes(2);
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start.AddMinutes(1)),  // Watermark: none -> -1. Windows: [0,10)
+            Timestamped.Create(2, start.AddMinutes(6)),  // Watermark: -1 -> 4. Windows: [0,10), [5,15)
+            Timestamped.Create(3, start.AddMinutes(3)),  // Watermark: 4. 3 <= 4, so LATE. Dropped.
+            Timestamped.Create(4, start.AddMinutes(12)), // Watermark: 4 -> 10. [0,10) completes. Windows: [5,15), [10,20)
+            Timestamped.Create(5, start.AddMinutes(9)),  // Watermark: 10. 9 <= 10, so LATE. Dropped.
+        };
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration, slide, outOfOrderness: outOfOrderness);
+
+        var windowList = new List<List<int>>();
+        await windows.FlatMap(async w =>
+        {
+            var list = await w.Map(x => x.Value).ToListAsync();
+            lock (windowList) windowList.Add(list);
+            return 0;
+        }).DrainAsync();
+
+        // Expected Windows and their items:
+        // [-5, 5): {1}     (3 was late)
+        // [0, 10): {1, 2}  (3 was late)
+        // [5, 15): {2, 4}  (3 was late, 9 was late)
+        // [10, 20): {4}    (9 was late)
+
+        Assert.That(windowList, Has.Count.EqualTo(4));
+        Assert.That(windowList, Has.Some.EquivalentTo(new[] { 1 }));
+        Assert.That(windowList, Has.Some.EquivalentTo(new[] { 1, 2 }));
+        Assert.That(windowList, Has.Some.EquivalentTo(new[] { 2, 4 }));
+        Assert.That(windowList, Has.Some.EquivalentTo(new[] { 4 }));
+    }
+
+    [Test]
+    public async Task WindowByTime_Watermark_ShouldCompleteAtExactBoundary()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(10);
+        var outOfOrderness = TimeSpan.Zero;
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start.AddMinutes(1)),
+            Timestamped.Create(2, start.AddMinutes(10)), // Watermark: 10. Window [0, 10) should complete.
+        };
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration, outOfOrderness: outOfOrderness);
+
+        var windowList = new List<List<int>>();
+        await windows.FlatMap(async w =>
+        {
+            var list = await w.Map(x => x.Value).ToListAsync();
+            lock (windowList) windowList.Add(list);
+            return 0;
+        }).DrainAsync();
+
+        Assert.That(windowList, Has.Count.EqualTo(2));
+        Assert.That(windowList, Has.Some.EquivalentTo(new[] { 1 }));
+        Assert.That(windowList, Has.Some.EquivalentTo(new[] { 2 }));
+    }
+
+    [Test]
+    public async Task WindowByTime_Watermark_ShouldDropIfEqualToWatermark()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(10);
+        var outOfOrderness = TimeSpan.FromMinutes(5);
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start.AddMinutes(10)), // Watermark: 5
+            Timestamped.Create(2, start.AddMinutes(5)),  // Watermark: 5. 5 <= 5 is LATE.
+        };
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration, outOfOrderness: outOfOrderness);
+
+        var windowList = new List<List<int>>();
+        await windows.FlatMap(async w =>
+        {
+            var list = await w.Map(x => x.Value).ToListAsync();
+            lock (windowList) windowList.Add(list);
+            return 0;
+        }).DrainAsync();
+
+        Assert.That(windowList, Has.Count.EqualTo(1));
+        Assert.That(windowList[0], Is.EquivalentTo(new[] { 1 }));
+    }
+
+    [Test]
+    public async Task WindowByTime_Watermark_UpstreamCompletion_ShouldFlushAll()
+    {
+        var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var duration = TimeSpan.FromMinutes(10);
+        var outOfOrderness = TimeSpan.FromMinutes(100); // Watermark will always be far in the past
+
+        var items = new[]
+        {
+            Timestamped.Create(1, start.AddMinutes(1)),
+            Timestamped.Create(2, start.AddMinutes(5)),
+        };
+
+        var source = Stream.From(items);
+        var windows = source.WindowByTime(duration, outOfOrderness: outOfOrderness);
+
+        var windowList = new List<List<int>>();
+        await windows.FlatMap(async w =>
+        {
+            var list = await w.Map(x => x.Value).ToListAsync();
+            lock (windowList) windowList.Add(list);
+            return 0;
+        }).DrainAsync();
+
+        // Even though watermark never reached 10, upstream completion should close the window.
+        Assert.That(windowList, Has.Count.EqualTo(1));
+        Assert.That(windowList[0], Is.EquivalentTo(new[] { 1, 2 }));
+    }
+}

--- a/src/Streamix/Extensions/TimeseriesExtensions.cs
+++ b/src/Streamix/Extensions/TimeseriesExtensions.cs
@@ -29,20 +29,107 @@ public static class TimeseriesExtensions
     /// <param name="slide">The interval at which windows are started. If null, tumbling windows are used (slide = duration).</param>
     /// <param name="capacity">The capacity of the buffer for each window.</param>
     /// <param name="mode">The backpressure mode for each window.</param>
+    /// <param name="outOfOrderness">The maximum duration by which events can be out of order. If specified, watermark-aware processing is enabled.</param>
     /// <returns>A stream of window streams.</returns>
     public static IStream<IStream<Timestamped<T>>> WindowByTime<T>(
         this IStream<Timestamped<T>> source,
         TimeSpan duration,
         TimeSpan? slide = null,
         int capacity = 16,
-        ChannelBackpressureMode mode = ChannelBackpressureMode.Wait)
+        ChannelBackpressureMode mode = ChannelBackpressureMode.Wait,
+        TimeSpan? outOfOrderness = null)
     {
         if (duration <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(duration));
         if (slide.HasValue && slide.Value <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(slide));
+        if (outOfOrderness.HasValue && outOfOrderness.Value < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(outOfOrderness));
 
         return Stream.Create<IStream<Timestamped<T>>>(async emitter =>
         {
             var ct = emitter.CancellationToken;
+
+            if (outOfOrderness.HasValue)
+            {
+                var ooo = outOfOrderness.Value;
+                var effectiveSlide = slide ?? duration;
+                var activeWindows = new SortedDictionary<long, Channel<Timestamped<T>>>();
+                long? maxObservedTicks = null;
+
+                try
+                {
+                    await foreach (var item in source.WithCancellation(ct))
+                    {
+                        if (maxObservedTicks.HasValue)
+                        {
+                            var watermarkTicks = maxObservedTicks.Value - ooo.Ticks;
+                            if (item.Timestamp.UtcTicks <= watermarkTicks)
+                            {
+                                continue; // Late event, drop
+                            }
+                        }
+
+                        // Identify windows this item belongs to
+                        // Window starts at s where s is multiple of effectiveSlide
+                        // s <= item.Timestamp < s + duration
+                        var latestStartTicks = (item.Timestamp.UtcTicks / effectiveSlide.Ticks) * effectiveSlide.Ticks;
+                        var windowsToCreate = new List<long>();
+                        for (var s = latestStartTicks; s > item.Timestamp.UtcTicks - duration.Ticks; s -= effectiveSlide.Ticks)
+                        {
+                            if (s < 0) break;
+                            if (!activeWindows.ContainsKey(s)) windowsToCreate.Add(s);
+                        }
+                        windowsToCreate.Reverse();
+
+                        foreach (var s in windowsToCreate)
+                        {
+                            var channel = ChannelExecution.CreateChannel<Timestamped<T>>(capacity, mode, singleWriter: true);
+                            activeWindows[s] = channel;
+                            await emitter.EmitAsync(Stream.From(innerCt => channel.Reader.ReadAllAsync(innerCt)));
+                        }
+
+                        for (var s = latestStartTicks; s > item.Timestamp.UtcTicks - duration.Ticks; s -= effectiveSlide.Ticks)
+                        {
+                            if (s < 0) break;
+                            await ChannelExecution.WriteAsync(activeWindows[s].Writer, item, mode, ct);
+                        }
+
+                        if (!maxObservedTicks.HasValue || item.Timestamp.UtcTicks > maxObservedTicks.Value)
+                        {
+                            maxObservedTicks = item.Timestamp.UtcTicks;
+                            var newWatermarkTicks = maxObservedTicks.Value - ooo.Ticks;
+
+                            var toRemove = new List<long>();
+                            foreach (var kvp in activeWindows)
+                            {
+                                if (kvp.Key + duration.Ticks <= newWatermarkTicks)
+                                {
+                                    kvp.Value.Writer.TryComplete();
+                                    toRemove.Add(kvp.Key);
+                                }
+                                else
+                                {
+                                    break;
+                                }
+                            }
+                            foreach (var key in toRemove) activeWindows.Remove(key);
+                        }
+                    }
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                }
+                catch (Exception ex)
+                {
+                    foreach (var window in activeWindows.Values) window.Writer.TryComplete(ex);
+                    throw;
+                }
+                finally
+                {
+                    foreach (var window in activeWindows.Values) window.Writer.TryComplete();
+                    activeWindows.Clear();
+                }
+
+                return;
+            }
 
             if (slide == null || slide == duration)
             {
@@ -122,7 +209,6 @@ public static class TimeseriesExtensions
                         var effectiveMinStart = Math.Max(item.Timestamp.UtcTicks - duration.Ticks + 1, firstStartTicks.Value);
 
                         // Identify windows to create (in chronological order)
-
                         var windowsToCreate = new List<long>();
                         for (var s = latestStartTicks; s >= effectiveMinStart; s -= slide.Value.Ticks)
                         {


### PR DESCRIPTION
This PR implements Task 2 from `docs/TIMESERIES.md`, introducing watermark-aware event-time processing to the `WindowByTime` operator.
 
Key changes:
- `WindowByTime` now accepts an optional `outOfOrderness` parameter.
- When `outOfOrderness` is provided, the operator tracks `maxObservedEventTimestamp` and derives a monotonic watermark.
- Late events (where `timestamp <= watermark`) are dropped from the main output.
- Windows are completed and emitted only when the watermark reaches or exceeds the window's end boundary.
- Upstream completion triggers an immediate flush of all remaining open windows.
- In the sliding window case, new windows are emitted in chronological (start-time) order.
- Documentation in `ARCHITECTURE.md` and `README.md` has been updated to reflect these new semantics.
- A new test suite `WatermarkTests.cs` covers in-order, out-of-order, and late event scenarios.

---
*PR created automatically by Jules for task [689739721209636400](https://jules.google.com/task/689739721209636400) started by @khurram-uworx*